### PR TITLE
Disable node interaction when no metadata is available in network area diagram viewer

### DIFF
--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -97,9 +97,15 @@ export class NetworkAreaDiagramViewer {
         this.originalWidth = 0;
         this.originalHeight = 0;
         this.dynamicCssRules = customDynamicCssRules ?? DEFAULT_DYNAMIC_CSS_RULES;
-        // if no metadata is available disable node interaction
-        enableNodeInteraction = diagramMetadata == null ? false : enableNodeInteraction;
-        this.init(minWidth, minHeight, maxWidth, maxHeight, enableNodeInteraction, enableLevelOfDetail);
+        this.init(
+            minWidth,
+            minHeight,
+            maxWidth,
+            maxHeight,
+            enableNodeInteraction,
+            enableLevelOfDetail,
+            diagramMetadata !== null
+        );
         this.svgParameters = new SvgParameters(diagramMetadata?.svgParameters);
         this.layoutParameters = new LayoutParameters(diagramMetadata?.layoutParameters);
         this.onMoveNodeCallback = onMoveNodeCallback;
@@ -193,7 +199,8 @@ export class NetworkAreaDiagramViewer {
         maxWidth: number,
         maxHeight: number,
         enableNodeInteraction: boolean,
-        enableLevelOfDetail: boolean
+        enableLevelOfDetail: boolean,
+        hasMetadata: boolean
     ): void {
         if (!this.container || !this.svgContent) {
             return;
@@ -222,7 +229,7 @@ export class NetworkAreaDiagramViewer {
         drawnSvg.style.overflow = 'visible';
 
         // add events
-        if (enableNodeInteraction) {
+        if (enableNodeInteraction && hasMetadata) {
             this.svgDraw.on('mousedown', (e: Event) => {
                 if ((e as MouseEvent).button == 0) {
                     this.onMouseLeftDown(e as MouseEvent);
@@ -237,9 +244,11 @@ export class NetworkAreaDiagramViewer {
                 }
             });
         }
-        this.svgDraw.on('mouseover', (e: Event) => {
-            this.onHover(e as MouseEvent);
-        });
+        if (hasMetadata) {
+            this.svgDraw.on('mouseover', (e: Event) => {
+                this.onHover(e as MouseEvent);
+            });
+        }
         this.svgDraw.on('panStart', function () {
             if (drawnSvg.parentElement != undefined) {
                 drawnSvg.parentElement.style.cursor = 'move';
@@ -284,7 +293,7 @@ export class NetworkAreaDiagramViewer {
             observer.observe(targetNode, { attributeFilter: ['viewBox'] });
         }
 
-        if (enableNodeInteraction) {
+        if (enableNodeInteraction && hasMetadata) {
             // fill empty elements: unknown buses and three windings transformers
             const emptyElements: NodeListOf<SVGGraphicsElement> = this.container.querySelectorAll(
                 '.nad-unknown-busnode, .nad-3wt-nodes .nad-winding'

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -97,6 +97,8 @@ export class NetworkAreaDiagramViewer {
         this.originalWidth = 0;
         this.originalHeight = 0;
         this.dynamicCssRules = customDynamicCssRules ?? DEFAULT_DYNAMIC_CSS_RULES;
+        // if no metadata is available disable node interaction
+        enableNodeInteraction = diagramMetadata == null ? false : enableNodeInteraction;
         this.init(minWidth, minHeight, maxWidth, maxHeight, enableNodeInteraction, enableLevelOfDetail);
         this.svgParameters = new SvgParameters(diagramMetadata?.svgParameters);
         this.layoutParameters = new LayoutParameters(diagramMetadata?.layoutParameters);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
In network area diagram viewer, the node interaction can be enabled even if there is no metadata available


**What is the new behavior (if this is a feature change)?**
In network area diagram viewer, when there is no metadata available the node interaction is disabled


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No