### PR TITLE
Add save callback and buttons to NAD viewer

### DIFF
--- a/demo/src/diagram-viewers/add-diagrams.ts
+++ b/demo/src/diagram-viewers/add-diagrams.ts
@@ -33,8 +33,10 @@ import {
     OnMoveNodeCallbackType,
     OnMoveTextNodeCallbackType,
     OnSelectNodeCallbackType,
+    OnToggleNadHoverCallbackType,
+    OnSaveCallbackType,
+    MouseMode,
 } from '../../../src';
-import { OnToggleNadHoverCallbackType } from '../../../src/components/network-area-diagram-viewer/network-area-diagram-viewer';
 
 export const addNadToDemo = () => {
     fetch(NadSvgExample)
@@ -54,13 +56,13 @@ export const addNadToDemo = () => {
                 true,
                 false,
                 null,
-                handleToggleNadHover
+                handleToggleNadHover,
+                handleSave,
+                true,
+                MouseMode.MOVE
             );
 
-            document
-                .getElementById('svg-container-nad')
-                ?.getElementsByTagName('svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+            document.getElementById('svg-container-nad')?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 
     fetch(NadSvgExample)
@@ -74,19 +76,21 @@ export const addNadToDemo = () => {
                 600,
                 1000,
                 1200,
-                handleNodeMove,
-                handleTextNodeMove,
+                null,
+                null,
                 handleNodeSelect,
                 false,
                 false,
                 null,
-                handleToggleNadHover
+                handleToggleNadHover,
+                handleSave,
+                true,
+                null
             );
 
             document
                 .getElementById('svg-container-nad-no-moving')
-                ?.getElementsByTagName('svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 
     fetch(NadSvgMultibusVLNodesExample)
@@ -106,13 +110,15 @@ export const addNadToDemo = () => {
                 true,
                 false,
                 null,
-                handleToggleNadHover
+                handleToggleNadHover,
+                handleSave,
+                true,
+                MouseMode.MOVE
             );
 
             document
                 .getElementById('svg-container-nad-multibus-vlnodes')
-                ?.getElementsByTagName('svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 
     fetch(NadSvgMultibusVLNodes14Example)
@@ -132,13 +138,15 @@ export const addNadToDemo = () => {
                 true,
                 false,
                 null,
-                handleToggleNadHover
+                handleToggleNadHover,
+                handleSave,
+                true,
+                MouseMode.MOVE
             );
 
             document
                 .getElementById('svg-container-nad-multibus-vlnodes14')
-                ?.getElementsByTagName('svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 
     fetch(NadSvgPstHvdcExample)
@@ -158,13 +166,15 @@ export const addNadToDemo = () => {
                 true,
                 false,
                 null,
-                handleToggleNadHover
+                handleToggleNadHover,
+                handleSave,
+                true,
+                MouseMode.MOVE
             );
 
             document
                 .getElementById('svg-container-nad-pst-hvdc')
-                ?.getElementsByTagName('svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 
     fetch(NadSvgThreeWTDanglingLineUnknownBusExample)
@@ -184,13 +194,15 @@ export const addNadToDemo = () => {
                 true,
                 false,
                 null,
-                handleToggleNadHover
+                handleToggleNadHover,
+                handleSave,
+                true,
+                MouseMode.SELECT
             );
 
             document
                 .getElementById('svg-container-nad-threewt-dl-ub')
-                ?.getElementsByTagName('svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 
     fetch(NadSvgPartialNetworkExample)
@@ -210,13 +222,15 @@ export const addNadToDemo = () => {
                 true,
                 true,
                 null,
-                handleToggleNadHover
+                handleToggleNadHover,
+                handleSave,
+                false,
+                MouseMode.MOVE
             );
 
             document
                 .getElementById('svg-container-nad-partial-network')
-                ?.getElementsByTagName('svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 };
 
@@ -414,4 +428,9 @@ const handleToggleNadHover: OnToggleNadHoverCallbackType = (hovered, mousePositi
             mousePosition?.y;
         console.log(msg);
     }
+};
+
+const handleSave: OnSaveCallbackType = (svg, metadata) => {
+    console.log(svg);
+    console.log(metadata);
 };

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -523,9 +523,10 @@ export function getTextNodeMoves(
     ];
 }
 
-function getButton(svg: string, pressed: boolean): HTMLButtonElement {
+function getButton(svg: string, title: string, pressed: boolean): HTMLButtonElement {
     const button = document.createElement('button');
     button.innerHTML = svg;
+    button.title = title;
     button.style.height = '25px';
     button.style.width = '25px';
     button.style.marginRight = '1px';
@@ -543,6 +544,7 @@ function getButton(svg: string, pressed: boolean): HTMLButtonElement {
 export function getSaveButton(): HTMLButtonElement {
     return getButton(
         '<svg xmlns="http://www.w3.org/2000/svg" height="15px" viewBox="0 -960 960 960" width="15px" fill="#5f6368"><path d="m720-120 160-160-56-56-64 64v-167h-80v167l-64-64-56 56 160 160ZM560 0v-80h320V0H560ZM240-160q-33 0-56.5-23.5T160-240v-560q0-33 23.5-56.5T240-880h280l240 240v121h-80v-81H480v-200H240v560h240v80H240Zm0-80v-560 560Z"/></svg>',
+        'Save',
         false
     );
 }
@@ -550,6 +552,7 @@ export function getSaveButton(): HTMLButtonElement {
 export function getMoveButton(pressed: boolean): HTMLButtonElement {
     return getButton(
         '<svg xmlns="http://www.w3.org/2000/svg" height="15px" viewBox="0 -960 960 960" width="15px" fill="#5f6368"><path d="M806-440H320v-80h486l-62-62 56-58 160 160-160 160-56-58 62-62ZM600-600v-160H200v560h400v-160h80v160q0 33-23.5 56.5T600-120H200q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h400q33 0 56.5 23.5T680-760v160h-80Z"/></svg>',
+        'Move',
         pressed
     );
 }
@@ -557,6 +560,7 @@ export function getMoveButton(pressed: boolean): HTMLButtonElement {
 export function getSelectButton(pressed: boolean): HTMLButtonElement {
     return getButton(
         '<svg xmlns="http://www.w3.org/2000/svg" height="15px" viewBox="0 -960 960 960" width="15px" fill="#5f6368"><path d="M40-480v-80h80v80H40Zm800 0v-80h80v80h-80ZM40-640v-80h80v80H40Zm800 0v-80h80v80h-80ZM40-800v-80h80v80H40Zm160 320v-80h80v80h-80Zm480 0v-80h80v80h-80Zm160-320v-80h80v80h-80Zm-640 0v-80h80v80h-80Zm160 0v-80h80v80h-80Zm160 0v-80h80v80h-80Zm160 0v-80h80v80h-80ZM473-40q-24 0-46-9t-39-26L184-280l33-34q14-14 34-19t40 0l69 20v-327q0-17 11.5-28.5T400-680q17 0 28.5 11.5T440-640v433l-98-28 103 103q6 6 13 9t15 3h167q33 0 56.5-23.5T720-200v-160q0-17 11.5-28.5T760-400q17 0 28.5 11.5T800-360v160q0 66-47 113T640-40H473Zm7-280v-160q0-17 11.5-28.5T520-520q17 0 28.5 11.5T560-480v160h-80Zm120 0v-120q0-17 11.5-28.5T640-480q17 0 28.5 11.5T680-440v120h-80Zm40 200H445h195Z"/></svg>',
+        'Select',
         pressed
     );
 }

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 
 import { Point } from '@svgdotjs/svg.js';
@@ -126,7 +127,7 @@ export function getLabelData(point1: Point, point2: Point, arrowLabelShift: numb
 }
 
 // get fork position of a multibranch edge
-export function getEdgeFork(point: Point, edgeForkLength: number, angleFork: number) {
+export function getEdgeFork(point: Point, edgeForkLength: number, angleFork: number): Point {
     return new Point(point.x + edgeForkLength * Math.cos(angleFork), point.y + edgeForkLength * Math.sin(angleFork));
 }
 
@@ -520,4 +521,50 @@ export function getTextNodeMoves(
         { xOrig: textNode.shiftX, yOrig: textNode.shiftY, xNew: xNew, yNew: yNew },
         { xOrig: textNode.connectionShiftX, yOrig: textNode.connectionShiftY, xNew: connXNew, yNew: connYNew },
     ];
+}
+
+function getButton(svg: string, pressed: boolean): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.innerHTML = svg;
+    button.style.height = '20px';
+    button.style.width = '20px';
+    button.style.marginRight = '1px';
+    button.style.marginLeft = '2px';
+    button.style.marginTop = '1px';
+    button.style.padding = '0px';
+    if (pressed) {
+        button.style.boxShadow = 'none';
+    } else {
+        button.style.boxShadow = '0px 1px 2px rgba(0, 0, 0, 1)';
+    }
+    return button;
+}
+
+export function getSaveButton(): HTMLButtonElement {
+    return getButton(
+        '<svg xmlns="http://www.w3.org/2000/svg" height="15px" viewBox="0 -960 960 960" width="15px" fill="#5f6368"><path d="m720-120 160-160-56-56-64 64v-167h-80v167l-64-64-56 56 160 160ZM560 0v-80h320V0H560ZM240-160q-33 0-56.5-23.5T160-240v-560q0-33 23.5-56.5T240-880h280l240 240v121h-80v-81H480v-200H240v560h240v80H240Zm0-80v-560 560Z"/></svg>',
+        false
+    );
+}
+
+export function getMoveButton(pressed: boolean): HTMLButtonElement {
+    return getButton(
+        '<svg xmlns="http://www.w3.org/2000/svg" height="15px" viewBox="0 -960 960 960" width="15px" fill="#5f6368"><path d="M806-440H320v-80h486l-62-62 56-58 160 160-160 160-56-58 62-62ZM600-600v-160H200v560h400v-160h80v160q0 33-23.5 56.5T600-120H200q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h400q33 0 56.5 23.5T680-760v160h-80Z"/></svg>',
+        pressed
+    );
+}
+
+export function getSelectButton(pressed: boolean): HTMLButtonElement {
+    return getButton(
+        '<svg xmlns="http://www.w3.org/2000/svg" height="15px" viewBox="0 -960 960 960" width="15px" fill="#5f6368"><path d="M40-480v-80h80v80H40Zm800 0v-80h80v80h-80ZM40-640v-80h80v80H40Zm800 0v-80h80v80h-80ZM40-800v-80h80v80H40Zm160 320v-80h80v80h-80Zm480 0v-80h80v80h-80Zm160-320v-80h80v80h-80Zm-640 0v-80h80v80h-80Zm160 0v-80h80v80h-80Zm160 0v-80h80v80h-80Zm160 0v-80h80v80h-80ZM473-40q-24 0-46-9t-39-26L184-280l33-34q14-14 34-19t40 0l69 20v-327q0-17 11.5-28.5T400-680q17 0 28.5 11.5T440-640v433l-98-28 103 103q6 6 13 9t15 3h167q33 0 56.5-23.5T720-200v-160q0-17 11.5-28.5T760-400q17 0 28.5 11.5T800-360v160q0 66-47 113T640-40H473Zm7-280v-160q0-17 11.5-28.5T520-520q17 0 28.5 11.5T560-480v160h-80Zm120 0v-120q0-17 11.5-28.5T640-480q17 0 28.5 11.5T680-440v120h-80Zm40 200H445h195Z"/></svg>',
+        pressed
+    );
+}
+
+export function pressButton(button: HTMLButtonElement) {
+    button.style.boxShadow = 'none';
+}
+
+export function releaseButton(button: HTMLButtonElement) {
+    button.style.boxShadow = '0px 1px 2px rgba(0, 0, 0, 1)';
 }

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -526,16 +526,16 @@ export function getTextNodeMoves(
 function getButton(svg: string, pressed: boolean): HTMLButtonElement {
     const button = document.createElement('button');
     button.innerHTML = svg;
-    button.style.height = '20px';
-    button.style.width = '20px';
+    button.style.height = '25px';
+    button.style.width = '25px';
     button.style.marginRight = '1px';
-    button.style.marginLeft = '2px';
-    button.style.marginTop = '1px';
+    button.style.marginLeft = '3px';
+    button.style.marginTop = '3px';
     button.style.padding = '0px';
     if (pressed) {
-        button.style.boxShadow = 'none';
+        button.style.border = 'medium solid orange';
     } else {
-        button.style.boxShadow = '0px 1px 2px rgba(0, 0, 0, 1)';
+        button.style.border = 'none';
     }
     return button;
 }
@@ -562,9 +562,9 @@ export function getSelectButton(pressed: boolean): HTMLButtonElement {
 }
 
 export function pressButton(button: HTMLButtonElement) {
-    button.style.boxShadow = 'none';
+    button.style.border = 'medium solid orange';
 }
 
 export function releaseButton(button: HTMLButtonElement) {
-    button.style.boxShadow = '0px 1px 2px rgba(0, 0, 0, 1)';
+    button.style.border = 'none';
 }

--- a/src/components/network-area-diagram-viewer/layout-parameters.ts
+++ b/src/components/network-area-diagram-viewer/layout-parameters.ts
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 
 import { LayoutParametersMetadata } from './diagram-metadata';

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.test.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.test.ts
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 
 import { NetworkAreaDiagramViewer } from './network-area-diagram-viewer';
@@ -26,6 +27,9 @@ describe('Test network-area-diagram-viewer', () => {
             false,
             false,
             null,
+            null,
+            null,
+            false,
             null
         );
 

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -236,7 +236,7 @@ export class NetworkAreaDiagramViewer {
 
         // add buttons bar
         if (addButtons) {
-            this.container.appendChild(this.GetButtonsBar(enableNodeInteraction));
+            this.container.appendChild(this.GetButtonsBar(enableNodeInteraction && hasMetadata));
         }
 
         // add svg div
@@ -332,13 +332,13 @@ export class NetworkAreaDiagramViewer {
         }
     }
 
-    private GetButtonsBar(enableNodeMoving: boolean): HTMLDivElement {
+    private GetButtonsBar(showNodeInteractionButtons: boolean): HTMLDivElement {
         const buttonsDiv = document.createElement('div');
         buttonsDiv.style.display = 'flex';
         buttonsDiv.style.alignItems = 'center';
         buttonsDiv.style.position = 'absolute';
         buttonsDiv.style.zIndex = '2';
-        if (enableNodeMoving) {
+        if (showNodeInteractionButtons) {
             const moveButton = DiagramUtils.getMoveButton(this.mouseMode === MouseMode.MOVE);
             buttonsDiv.appendChild(moveButton);
             const selectButton = DiagramUtils.getSelectButton(this.mouseMode === MouseMode.SELECT);

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 
 import { Point, SVG, ViewBoxLike, Svg } from '@svgdotjs/svg.js';
@@ -15,6 +16,11 @@ import { CSS_DECLARATION, CSS_RULE, THRESHOLD_STATUS, DEFAULT_DYNAMIC_CSS_RULES 
 
 type DIMENSIONS = { width: number; height: number; viewbox: VIEWBOX };
 type VIEWBOX = { x: number; y: number; width: number; height: number };
+
+export enum MouseMode {
+    MOVE,
+    SELECT,
+}
 
 export type OnMoveNodeCallbackType = (
     equipmentId: string,
@@ -40,6 +46,7 @@ export type OnMoveTextNodeCallbackType = (
 ) => void;
 
 export type OnSelectNodeCallbackType = (equipmentId: string, nodeId: string) => void;
+
 export type OnToggleNadHoverCallbackType = (
     hovered: boolean,
     mousePosition: Point | null,
@@ -47,8 +54,11 @@ export type OnToggleNadHoverCallbackType = (
     equipmentType: string
 ) => void;
 
+export type OnSaveCallbackType = (svg: string | null, metadata: string | null) => void;
+
 export class NetworkAreaDiagramViewer {
     container: HTMLElement;
+    svgDiv: HTMLElement;
     svgContent: string;
     diagramMetadata: DiagramMetadata | null;
     width: number;
@@ -72,6 +82,8 @@ export class NetworkAreaDiagramViewer {
     onSelectNodeCallback: OnSelectNodeCallbackType | null;
     dynamicCssRules: CSS_RULE[];
     onToggleHoverCallback: OnToggleNadHoverCallbackType | null;
+    onSaveCallback: OnSaveCallbackType | null;
+    mouseMode: MouseMode;
 
     constructor(
         container: HTMLElement,
@@ -87,9 +99,13 @@ export class NetworkAreaDiagramViewer {
         enableNodeInteraction: boolean,
         enableLevelOfDetail: boolean,
         customDynamicCssRules: CSS_RULE[] | null,
-        onToggleHoverCallback: OnToggleNadHoverCallbackType | null
+        onToggleHoverCallback: OnToggleNadHoverCallbackType | null,
+        onSaveCallback: OnSaveCallbackType | null,
+        addButtons: boolean,
+        defaultMouseMode: MouseMode | null
     ) {
         this.container = container;
+        this.svgDiv = document.createElement('div');
         this.svgContent = svgContent;
         this.diagramMetadata = diagramMetadata;
         this.width = 0;
@@ -97,6 +113,12 @@ export class NetworkAreaDiagramViewer {
         this.originalWidth = 0;
         this.originalHeight = 0;
         this.dynamicCssRules = customDynamicCssRules ?? DEFAULT_DYNAMIC_CSS_RULES;
+        this.mouseMode = defaultMouseMode ?? MouseMode.MOVE;
+        this.onMoveNodeCallback = onMoveNodeCallback;
+        this.onMoveTextNodeCallback = onMoveTextNodeCallback;
+        this.onSelectNodeCallback = onSelectNodeCallback;
+        this.onToggleHoverCallback = onToggleHoverCallback;
+        this.onSaveCallback = onSaveCallback;
         this.init(
             minWidth,
             minHeight,
@@ -104,14 +126,11 @@ export class NetworkAreaDiagramViewer {
             maxHeight,
             enableNodeInteraction,
             enableLevelOfDetail,
-            diagramMetadata !== null
+            diagramMetadata !== null,
+            addButtons
         );
         this.svgParameters = new SvgParameters(diagramMetadata?.svgParameters);
         this.layoutParameters = new LayoutParameters(diagramMetadata?.layoutParameters);
-        this.onMoveNodeCallback = onMoveNodeCallback;
-        this.onMoveTextNodeCallback = onMoveTextNodeCallback;
-        this.onSelectNodeCallback = onSelectNodeCallback;
-        this.onToggleHoverCallback = onToggleHoverCallback;
     }
 
     public setWidth(width: number): void {
@@ -184,7 +203,7 @@ export class NetworkAreaDiagramViewer {
     public moveNodeToCoordinates(equipmentId: string, x: number, y: number) {
         const nodeId = this.getNodeIdFromEquipmentId(equipmentId);
         if (nodeId != null) {
-            const elemToMove: SVGElement | null = this.container.querySelector('[id="' + nodeId + '"]');
+            const elemToMove: SVGElement | null = this.svgDiv.querySelector('[id="' + nodeId + '"]');
             if (elemToMove) {
                 const newPosition = new Point(x, y);
                 this.onDragStart(elemToMove);
@@ -200,7 +219,8 @@ export class NetworkAreaDiagramViewer {
         maxHeight: number,
         enableNodeInteraction: boolean,
         enableLevelOfDetail: boolean,
-        hasMetadata: boolean
+        hasMetadata: boolean,
+        addButtons: boolean
     ): void {
         if (!this.container || !this.svgContent) {
             return;
@@ -214,6 +234,14 @@ export class NetworkAreaDiagramViewer {
         // clear the previous svg in div element before replacing
         this.container.innerHTML = '';
 
+        // add buttons bar
+        if (addButtons) {
+            this.container.appendChild(this.GetButtonsBar(enableNodeInteraction));
+        }
+
+        // add svg div
+        this.container.appendChild(this.svgDiv);
+
         // set dimensions
         this.setOriginalWidth(dimensions.width);
         this.setOriginalHeight(dimensions.height);
@@ -222,7 +250,7 @@ export class NetworkAreaDiagramViewer {
 
         // set the SVG
         this.svgDraw = SVG()
-            .addTo(this.container)
+            .addTo(this.svgDiv)
             .size(this.width, this.height)
             .viewbox(dimensions.viewbox.x, dimensions.viewbox.y, dimensions.viewbox.width, dimensions.viewbox.height);
         const drawnSvg: HTMLElement = <HTMLElement>this.svgDraw.svg(this.svgContent).node.firstElementChild;
@@ -295,13 +323,55 @@ export class NetworkAreaDiagramViewer {
 
         if (enableNodeInteraction && hasMetadata) {
             // fill empty elements: unknown buses and three windings transformers
-            const emptyElements: NodeListOf<SVGGraphicsElement> = this.container.querySelectorAll(
+            const emptyElements: NodeListOf<SVGGraphicsElement> = this.svgDiv.querySelectorAll(
                 '.nad-unknown-busnode, .nad-3wt-nodes .nad-winding'
             );
             emptyElements.forEach((emptyElement) => {
                 emptyElement.style.fill = '#0000';
             });
         }
+    }
+
+    private GetButtonsBar(enableNodeMoving: boolean): HTMLDivElement {
+        const buttonsDiv = document.createElement('div');
+        buttonsDiv.style.display = 'flex';
+        buttonsDiv.style.alignItems = 'center';
+        buttonsDiv.style.position = 'absolute';
+        buttonsDiv.style.zIndex = '2';
+        if (enableNodeMoving) {
+            const moveButton = DiagramUtils.getMoveButton(this.mouseMode === MouseMode.MOVE);
+            buttonsDiv.appendChild(moveButton);
+            const selectButton = DiagramUtils.getSelectButton(this.mouseMode === MouseMode.SELECT);
+            buttonsDiv.appendChild(selectButton);
+            moveButton.addEventListener('click', () => {
+                this.mouseMode = MouseMode.MOVE;
+                DiagramUtils.pressButton(moveButton);
+                DiagramUtils.releaseButton(selectButton);
+            });
+            selectButton.addEventListener('click', () => {
+                this.mouseMode = MouseMode.SELECT;
+                DiagramUtils.pressButton(selectButton);
+                DiagramUtils.releaseButton(moveButton);
+            });
+        }
+        if (this.onSaveCallback != null) {
+            const saveSvgButton = DiagramUtils.getSaveButton();
+            buttonsDiv.appendChild(saveSvgButton);
+            saveSvgButton.addEventListener('click', () => {
+                if (this.onSaveCallback != null) {
+                    this.onSaveCallback(this.getSvg(), this.getMetadata());
+                }
+            });
+        }
+        return buttonsDiv;
+    }
+
+    public getSvg(): string | null {
+        return this.svgDraw !== undefined ? this.svgDraw.svg() : null;
+    }
+
+    public getMetadata(): string | null {
+        return JSON.stringify(this.diagramMetadata);
     }
 
     public getDimensionsFromSvg(): DIMENSIONS | null {
@@ -338,10 +408,10 @@ export class NetworkAreaDiagramViewer {
 
     private onMouseLeftDown(event: MouseEvent) {
         // check dragging vs. selection
-        if (event.shiftKey) {
+        if (this.mouseMode == MouseMode.SELECT) {
             // selecting node
             this.onSelectStart(DiagramUtils.getSelectableFrom(event.target as SVGElement));
-        } else {
+        } else if (this.mouseMode == MouseMode.MOVE) {
             // moving node
             this.onDragStart(DiagramUtils.getDraggableFrom(event.target as SVGElement));
         }
@@ -470,7 +540,7 @@ export class NetworkAreaDiagramViewer {
 
     private dragVoltageLevelText(mousePosition: Point) {
         window.getSelection()?.empty(); // to avoid text highlighting in firefox
-        const vlNode: SVGGraphicsElement | null = this.container.querySelector(
+        const vlNode: SVGGraphicsElement | null = this.svgDiv.querySelector(
             "[id='" + DiagramUtils.getVoltageLevelNodeId(this.draggedElement?.id) + "']"
         );
         this.moveText(this.draggedElement, vlNode, mousePosition, DiagramUtils.getTextNodeAngleFromCentre);
@@ -478,7 +548,7 @@ export class NetworkAreaDiagramViewer {
 
     private dragVoltageLevelNode(mousePosition: Point) {
         this.moveNode(mousePosition);
-        const textNode: SVGGraphicsElement | null = this.container.querySelector(
+        const textNode: SVGGraphicsElement | null = this.svgDiv.querySelector(
             "[id='" + DiagramUtils.getTextNodeId(this.draggedElement?.id) + "']"
         );
         this.moveText(
@@ -533,7 +603,7 @@ export class NetworkAreaDiagramViewer {
         textHeight: number,
         textWidth: number
     ) {
-        const textEdge: SVGGraphicsElement | null = this.container.querySelector("[id='" + textEdgeId + "']");
+        const textEdge: SVGGraphicsElement | null = this.svgDiv.querySelector("[id='" + textEdgeId + "']");
         if (textEdge != null) {
             // compute voltage level circle radius
             const busNodes: BusNodeMetadata[] | undefined = this.diagramMetadata?.busNodes.filter(
@@ -565,7 +635,7 @@ export class NetworkAreaDiagramViewer {
     }
 
     private moveSvgElement(svgElementId: string, translation: Point) {
-        const svgElement: SVGGraphicsElement | null = this.container.querySelector("[id='" + svgElementId + "']");
+        const svgElement: SVGGraphicsElement | null = this.svgDiv.querySelector("[id='" + svgElementId + "']");
         if (svgElement) {
             const transform = DiagramUtils.getTransform(svgElement);
             const totalTranslation = new Point(
@@ -636,7 +706,7 @@ export class NetworkAreaDiagramViewer {
     // get the nodes at the sides of an edge
     private getEdgeNodes(edge: EdgeMetadata): [SVGGraphicsElement | null, SVGGraphicsElement | null] {
         const otherNodeId = this.draggedElement?.id === edge.node1 ? edge.node2 : edge.node1;
-        const otherNode: SVGGraphicsElement | null = this.container.querySelector("[id='" + otherNodeId + "']");
+        const otherNode: SVGGraphicsElement | null = this.svgDiv.querySelector("[id='" + otherNodeId + "']");
         const node1 = this.draggedElement?.id === edge.node1 ? this.draggedElement : otherNode;
         const node2 = otherNode?.id === edge.node1 ? this.draggedElement : otherNode;
         return [node1, node2];
@@ -684,9 +754,7 @@ export class NetworkAreaDiagramViewer {
                         return;
                     }
                     // get edge element
-                    const edgeNode: SVGGraphicsElement | null = this.container.querySelector(
-                        "[id='" + edge.svgId + "']"
-                    );
+                    const edgeNode: SVGGraphicsElement | null = this.svgDiv.querySelector("[id='" + edge.svgId + "']");
                     if (!edgeNode) {
                         return;
                     }
@@ -757,7 +825,7 @@ export class NetworkAreaDiagramViewer {
             return;
         }
         // get edge element
-        const edgeNode: SVGGraphicsElement | null = this.container.querySelector("[id='" + edge.svgId + "']");
+        const edgeNode: SVGGraphicsElement | null = this.svgDiv.querySelector("[id='" + edge.svgId + "']");
         if (!edgeNode) {
             return;
         }
@@ -1085,7 +1153,7 @@ export class NetworkAreaDiagramViewer {
         const angleId = busNode.svgId == edge.busNode1 ? edgeId + '.1' : edgeId + '.2';
         if (!this.edgeAngles.has(angleId)) {
             // if not yet stored in angle map -> compute and store it
-            const edgeNode: SVGGraphicsElement | null = this.container.querySelector("[id='" + edgeId + "']");
+            const edgeNode: SVGGraphicsElement | null = this.svgDiv.querySelector("[id='" + edgeId + "']");
             if (edgeNode) {
                 const side = busNode.svgId == edge.busNode1 ? 0 : 1;
                 const halfEdge: HTMLElement = <HTMLElement>edgeNode.children.item(side)?.firstElementChild;

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -236,7 +236,7 @@ export class NetworkAreaDiagramViewer {
 
         // add buttons bar
         if (addButtons) {
-            this.container.appendChild(this.GetButtonsBar(enableNodeInteraction && hasMetadata));
+            this.container.appendChild(this.getButtonsBar(enableNodeInteraction && hasMetadata));
         }
 
         // add svg div
@@ -332,7 +332,7 @@ export class NetworkAreaDiagramViewer {
         }
     }
 
-    private GetButtonsBar(showNodeInteractionButtons: boolean): HTMLDivElement {
+    private getButtonsBar(showNodeInteractionButtons: boolean): HTMLDivElement {
         const buttonsDiv = document.createElement('div');
         buttonsDiv.style.display = 'flex';
         buttonsDiv.style.alignItems = 'center';
@@ -359,7 +359,7 @@ export class NetworkAreaDiagramViewer {
             buttonsDiv.appendChild(saveSvgButton);
             saveSvgButton.addEventListener('click', () => {
                 if (this.onSaveCallback != null) {
-                    this.onSaveCallback(this.getSvg(), this.getMetadata());
+                    this.onSaveCallback(this.getSvg(), this.getJsonMetadata());
                 }
             });
         }
@@ -370,7 +370,7 @@ export class NetworkAreaDiagramViewer {
         return this.svgDraw !== undefined ? this.svgDraw.svg() : null;
     }
 
-    public getMetadata(): string | null {
+    public getJsonMetadata(): string | null {
         return JSON.stringify(this.diagramMetadata);
     }
 

--- a/src/components/network-area-diagram-viewer/svg-parameters.ts
+++ b/src/components/network-area-diagram-viewer/svg-parameters.ts
@@ -3,6 +3,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 
 import { SvgParametersMetadata } from './diagram-metadata';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,10 @@ export type {
     OnMoveNodeCallbackType,
     OnMoveTextNodeCallbackType,
     OnSelectNodeCallbackType,
+    OnToggleNadHoverCallbackType,
+    OnSaveCallbackType,
 } from './components/network-area-diagram-viewer/network-area-diagram-viewer';
+export { MouseMode } from './components/network-area-diagram-viewer/network-area-diagram-viewer';
 export { THRESHOLD_STATUS } from './components/network-area-diagram-viewer/dynamic-css-utils';
 export type { CSS_DECLARATION, CSS_RULE } from './components/network-area-diagram-viewer/dynamic-css-utils';
 export { SingleLineDiagramViewer } from './components/single-line-diagram-viewer/single-line-diagram-viewer';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
feature


**What is the current behavior?**
In network area diagram viewer it is not possible to save updated SVG or metadata. 
By default the mouse is used for moving nodes. For selecting nodes the SHIFT key must be used.


**What is the new behavior (if this is a feature change)?**
A callback for saving SVG and metadata has been added.
Three buttons can be added to the viewer, two buttons for changing between moving nodes and selecting nodes, and one button for calling the save callback


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
the constructor of the NetworkAreaDiagramViewer has 3 additional parameters:
- the save callback
- the flag for enabling the visualization of the buttons
- the default action for the mouse: moving vs. selection

Examples are provided in the demo/src/diagram-viewers/add-diagrams.js file