### PR TITLE
fix zoom in NAD

### DIFF
--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -216,10 +216,10 @@ export class NetworkAreaDiagramViewer {
         this.container.innerHTML = '';
 
         // set dimensions
-        this.setOriginalWidth(dimensions.viewbox.width);
-        this.setOriginalHeight(dimensions.viewbox.height);
-        this.setWidth(Math.max(minWidth, Math.min(dimensions.viewbox.width, maxWidth)));
-        this.setHeight(Math.max(minHeight, Math.min(dimensions.viewbox.height, maxHeight)));
+        this.setOriginalWidth(dimensions.width);
+        this.setOriginalHeight(dimensions.height);
+        this.setWidth(dimensions.width < minWidth ? minWidth : Math.min(dimensions.width, maxWidth));
+        this.setHeight(dimensions.height < minHeight ? minHeight : Math.min(dimensions.height, maxHeight));
 
         // set the SVG
         this.svgDraw = SVG()

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -215,10 +215,10 @@ export class NetworkAreaDiagramViewer {
         this.container.innerHTML = '';
 
         // set dimensions
-        this.setOriginalWidth(dimensions.width);
-        this.setOriginalHeight(dimensions.height);
-        this.setWidth(dimensions.width < minWidth ? minWidth : Math.min(dimensions.width, maxWidth));
-        this.setHeight(dimensions.height < minHeight ? minHeight : Math.min(dimensions.height, maxHeight));
+        this.setOriginalWidth(dimensions.viewbox.width);
+        this.setOriginalHeight(dimensions.viewbox.height);
+        this.setWidth(Math.max(minWidth, Math.min(dimensions.viewbox.width, maxWidth)));
+        this.setHeight(Math.max(minHeight, Math.min(dimensions.viewbox.height, maxHeight)));
 
         // set the SVG
         this.svgDraw = SVG()
@@ -330,7 +330,6 @@ export class NetworkAreaDiagramViewer {
             zoomMin: 0.5 / this.ratio, // maximum zoom OUT ratio (0.5 = at best, the displayed area is twice the SVG's size)
             zoomMax: 20 * this.ratio, // maximum zoom IN ratio (20 = at best, the displayed area is only 1/20th of the SVG's size)
             zoomFactor: 0.2,
-            margins: { top: 0, left: 0, right: 0, bottom: 0 },
         });
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
When users zoom in and attempt to move the SLD, they encounter a limitation where movement in one direction becomes restricted after a certain zoom level. This issue affects the usability of the SLD, making it difficult for users to navigate the interface effectively.


**What kind of change does this PR introduce?**
remove the constraint on Zoompan


**What is the new behavior (if this is a feature change)?**
the movement is not constrained anymore

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
Steps to Reproduce the Bug:

1. Zoom in on a voltage level.
2.Attempt to move the labels or the voltage level itself.
3.Move towards the bottom.
4.At some point, observe that movement is restricted towards the bottom of the NAD.

