### PR TITLE
NAD: clone dynamic css rules to fix missing unapplied rules in some cases

### DIFF
--- a/src/components/network-area-diagram-viewer/dynamic-css-utils.ts
+++ b/src/components/network-area-diagram-viewer/dynamic-css-utils.ts
@@ -113,3 +113,5 @@ export const DEFAULT_DYNAMIC_CSS_RULES: CSS_RULE[] = [
         thresholdStatus: THRESHOLD_STATUS.ABOVE,
     },
 ];
+
+export const cloneRules = (rules: CSS_RULE[]) => rules.map((rule) => ({ ...rule }));

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -11,7 +11,13 @@ import * as DiagramUtils from './diagram-utils';
 import { SvgParameters, EdgeInfoEnum } from './svg-parameters';
 import { LayoutParameters } from './layout-parameters';
 import { DiagramMetadata, EdgeMetadata, BusNodeMetadata, NodeMetadata, TextNodeMetadata } from './diagram-metadata';
-import { CSS_DECLARATION, CSS_RULE, THRESHOLD_STATUS, DEFAULT_DYNAMIC_CSS_RULES } from './dynamic-css-utils';
+import {
+    CSS_DECLARATION,
+    CSS_RULE,
+    THRESHOLD_STATUS,
+    DEFAULT_DYNAMIC_CSS_RULES,
+    cloneRules,
+} from './dynamic-css-utils';
 import { debounce } from '@mui/material';
 
 type DIMENSIONS = { width: number; height: number; viewbox: VIEWBOX };
@@ -118,7 +124,8 @@ export class NetworkAreaDiagramViewer {
         this.height = 0;
         this.originalWidth = 0;
         this.originalHeight = 0;
-        this.dynamicCssRules = customDynamicCssRules ?? DEFAULT_DYNAMIC_CSS_RULES;
+        // rules need to be cloned because we store the threshold inside them
+        this.dynamicCssRules = cloneRules(customDynamicCssRules ?? DEFAULT_DYNAMIC_CSS_RULES);
         this.init(
             minWidth,
             minHeight,


### PR DESCRIPTION
The status is stored inside the rule object so having a static variable means that if you have 2 nads the rules are not reapplied in the second one.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
sometimes dynamic rules are not reapplied 


**What is the new behavior (if this is a feature change)?**
always reapplied


**Does this PR introduce a breaking change or deprecate an API?**
NO