### PR TITLE
Fixes a positioning issue when dragging a textnode

### DIFF
--- a/src/components/network-area-diagram-viewer/diagram-utils.test.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.test.ts
@@ -270,13 +270,51 @@ test('getTextEdgeEnd', () => {
     expect(textEdgeEnd.y).toBe(110);
 });
 
-test('getTextNodeAngleFromCentre', () => {
-    // not so useful test: in the test scrollWidth and scrollHeight of the div element
-    // inside the foreignObject are not correctly detected, they are always 0,
-    // so the input position is not moved to the text box angle
-    const textNodeAngle = DiagramUtils.getTextNodeAngleFromCentre(getSvgTextNode(), new Point(240, -310));
-    expect(textNodeAngle.x).toBe(240);
-    expect(textNodeAngle.y).toBe(-310);
+test('getTextNodeTopLeftCornerFromCenter', () => {
+    // In the tests, the scrollWidth and scrollHeight of the foreignObject's div element are not correctly detected.
+    // We have to mock them to test the getTextNodeTopLeftCornerFromCenter function.
+
+    // Mock the SVGGraphicsElement and its child scroll dimensions
+    const mockGetSvgTextNode = getSvgTextNode();
+
+    // Mock the scrollWidth and scrollHeight on the first child
+    Object.defineProperty(mockGetSvgTextNode.firstElementChild, 'scrollWidth', {
+        value: 100,
+        writable: true,
+    });
+    Object.defineProperty(mockGetSvgTextNode.firstElementChild, 'scrollHeight', {
+        value: 50,
+        writable: true,
+    });
+
+    const textNodeTopLeftCorner = DiagramUtils.getTextNodeTopLeftCornerFromCenter(
+        mockGetSvgTextNode,
+        new Point(240, -310)
+    );
+    expect(textNodeTopLeftCorner.x).toBe(240 - 100 / 2);
+    expect(textNodeTopLeftCorner.y).toBe(-310 - 50 / 2);
+});
+
+test('getTextNodeCenterFromTopLeftCorner', () => {
+    // In the tests, the scrollWidth and scrollHeight of the foreignObject's div element are not correctly detected.
+    // We have to mock them to test the getTextNodeCenterFromTopLeftCorner function.
+
+    // Mock the SVGGraphicsElement and its child scroll dimensions
+    const mockGetSvgTextNode = getSvgTextNode();
+
+    // Mock the scrollWidth and scrollHeight on the first child
+    Object.defineProperty(mockGetSvgTextNode.firstElementChild, 'scrollWidth', {
+        value: 100,
+        writable: true,
+    });
+    Object.defineProperty(mockGetSvgTextNode.firstElementChild, 'scrollHeight', {
+        value: 50,
+        writable: true,
+    });
+
+    const textNodeCenter = DiagramUtils.getTextNodeCenterFromTopLeftCorner(mockGetSvgTextNode, new Point(290, -285));
+    expect(textNodeCenter.x).toBe(290 + 100 / 2);
+    expect(textNodeCenter.y).toBe(-285 + 50 / 2);
 });
 
 test('getTextNodeTranslatedPosition', () => {

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -458,11 +458,21 @@ export function getTextEdgeEnd(
     return new Point(textNodePosition.x, textNodePosition.y + detailedTextNodeYShift);
 }
 
-// get position of angle of a text box computing from the centre position
-export function getTextNodeAngleFromCentre(textNode: SVGGraphicsElement | null, centrePosition: Point): Point {
-    const scrollWidth = textNode?.firstElementChild?.scrollWidth ?? 0;
-    const scrollHeight = textNode?.firstElementChild?.scrollHeight ?? 0;
-    return new Point(centrePosition.x - scrollWidth / 2, centrePosition.y - scrollHeight / 2);
+// Get the top left corner position of a text box using the box's center position
+export function getTextNodeTopLeftCornerFromCenter(textNode: SVGGraphicsElement | null, centrePosition: Point): Point {
+    const textNodeWidth = textNode?.firstElementChild?.scrollWidth ?? 0;
+    const textNodeHeight = textNode?.firstElementChild?.scrollHeight ?? 0;
+    return new Point(centrePosition.x - textNodeWidth / 2, centrePosition.y - textNodeHeight / 2);
+}
+
+// Get the center position of a text box using the box's top left corner position
+export function getTextNodeCenterFromTopLeftCorner(
+    textNode: SVGGraphicsElement | null,
+    topLeftCornerPosition: Point
+): Point {
+    const textNodeWidth = textNode?.firstElementChild?.scrollWidth ?? 0;
+    const textNodeHeight = textNode?.firstElementChild?.scrollHeight ?? 0;
+    return new Point(topLeftCornerPosition.x + textNodeWidth / 2, topLeftCornerPosition.y + textNodeHeight / 2);
 }
 
 // get the position of a translated text box

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -1381,13 +1381,6 @@ export class NetworkAreaDiagramViewer {
                     textNodeMoves[1].xOrig,
                     textNodeMoves[1].yOrig
                 );
-                this.moveTextNodeToCoordinates(
-                    node.equipmentId,
-                    textNode.shiftX,
-                    textNode.shiftY,
-                    textNode.connectionShiftX,
-                    textNode.connectionShiftY
-                );
             }
         }
     }

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -260,8 +260,13 @@ export class NetworkAreaDiagramViewer {
         if (!elemToMove) {
             return;
         }
+        const textNodeWidth = elemToMove?.firstElementChild?.scrollWidth ?? 0;
+        const textNodeHeight = elemToMove?.firstElementChild?.scrollHeight ?? 0;
         this.endTextEdge = new Point(nodePosition.x + connectionShiftX, nodePosition.y + connectionShiftY);
-        this.moveElement(elemToMove, new Point(nodePosition.x + shiftX, nodePosition.y + shiftY));
+        this.moveElement(
+            elemToMove,
+            new Point(nodePosition.x + shiftX + textNodeWidth / 2, nodePosition.y + shiftY + textNodeHeight / 2)
+        );
         // update metadata only
         this.updateTextNodeMetadataCallback(
             elemToMove,

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -260,19 +260,17 @@ export class NetworkAreaDiagramViewer {
         if (!elemToMove) {
             return;
         }
-        const textNodeWidth = elemToMove?.firstElementChild?.scrollWidth ?? 0;
-        const textNodeHeight = elemToMove?.firstElementChild?.scrollHeight ?? 0;
         this.endTextEdge = new Point(nodePosition.x + connectionShiftX, nodePosition.y + connectionShiftY);
-        this.moveElement(
+
+        const textNodeTopLeftCornerPosition = new Point(nodePosition.x + shiftX, nodePosition.y + shiftY);
+        const textNodeCenterPosition = DiagramUtils.getTextNodeCenterFromTopLeftCorner(
             elemToMove,
-            new Point(nodePosition.x + shiftX + textNodeWidth / 2, nodePosition.y + shiftY + textNodeHeight / 2)
+            textNodeTopLeftCornerPosition
         );
+        this.moveElement(elemToMove, textNodeCenterPosition);
+
         // update metadata only
-        this.updateTextNodeMetadataCallback(
-            elemToMove,
-            new Point(nodePosition.x + shiftX, nodePosition.y + shiftY),
-            false
-        );
+        this.updateTextNodeMetadataCallback(elemToMove, textNodeCenterPosition, false);
     }
 
     public init(
@@ -577,7 +575,7 @@ export class NetworkAreaDiagramViewer {
 
     private moveVoltageLevelText(textNode: SVGGraphicsElement, vlNode: SVGGraphicsElement, mousePosition: Point) {
         window.getSelection()?.empty(); // to avoid text highlighting in firefox
-        this.moveText(textNode, vlNode, mousePosition, DiagramUtils.getTextNodeAngleFromCentre);
+        this.moveText(textNode, vlNode, mousePosition, DiagramUtils.getTextNodeTopLeftCornerFromCenter);
     }
 
     private moveVoltageLevelNode(vlNode: SVGGraphicsElement, mousePosition: Point) {
@@ -1360,7 +1358,7 @@ export class NetworkAreaDiagramViewer {
         );
         if (node != null && textNode != null) {
             // get new text node position
-            const textPosition = DiagramUtils.getTextNodeAngleFromCentre(textNodeElement, mousePosition);
+            const textPosition = DiagramUtils.getTextNodeTopLeftCornerFromCenter(textNodeElement, mousePosition);
             const textNodeMoves = DiagramUtils.getTextNodeMoves(textNode, node, textPosition, this.endTextEdge);
             // update text node position in metadata
             textNode.shiftX = textNodeMoves[0].xNew;
@@ -1382,6 +1380,13 @@ export class NetworkAreaDiagramViewer {
                     textNodeMoves[1].yNew,
                     textNodeMoves[1].xOrig,
                     textNodeMoves[1].yOrig
+                );
+                this.moveTextNodeToCoordinates(
+                    node.equipmentId,
+                    textNode.shiftX,
+                    textNode.shiftY,
+                    textNode.connectionShiftX,
+                    textNode.connectionShiftY
                 );
             }
         }


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

No

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Bug fix

**What is the current behavior?**
<!-- You can also link to an open issue here -->

The public function that asks to move a textnode to a position did not take into account the textnode's size. Because of this, the textnode was moved to its top left position instead of its center (where the mouse is as the user drags and drops the textnode).

**What is the new behavior (if this is a feature change)?**

When using the public moveTextNodeToCoordinates function to move a textnode to a given position, the text node is moved using its center instead of its top left position. This makes the movement behave as if the user drags and drops the textnode.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
