### PR TITLE
Add zoom to fit functionality and button to NAD viewer

### DIFF
--- a/demo/src/diagram-viewers/add-diagrams.ts
+++ b/demo/src/diagram-viewers/add-diagrams.ts
@@ -59,12 +59,13 @@ export const addNadToDemo = () => {
                 false,
                 null,
                 handleToggleNadHover,
-                handleRightClick
+                handleRightClick,
+                true
             );
 
             document
                 .getElementById('svg-container-nad')
-                ?.getElementsByTagName('svg')[0]
+                ?.querySelectorAll('div > svg')[0]
                 .setAttribute('style', 'border:2px; border-style:solid;');
 
             // add range slider to update branch labels
@@ -125,12 +126,13 @@ export const addNadToDemo = () => {
                 false,
                 null,
                 handleToggleNadHover,
-                handleRightClick
+                handleRightClick,
+                false
             );
 
             document
                 .getElementById('svg-container-nad-no-moving')
-                ?.getElementsByTagName('svg')[0]
+                ?.querySelectorAll('div > svg')[0]
                 .setAttribute('style', 'border:2px; border-style:solid;');
         });
 
@@ -152,12 +154,13 @@ export const addNadToDemo = () => {
                 false,
                 null,
                 handleToggleNadHover,
-                handleRightClick
+                handleRightClick,
+                true
             );
 
             document
                 .getElementById('svg-container-nad-multibus-vlnodes')
-                ?.getElementsByTagName('svg')[0]
+                ?.querySelectorAll('div > svg')[0]
                 .setAttribute('style', 'border:2px; border-style:solid;');
 
             // add button to update branch labels
@@ -198,12 +201,13 @@ export const addNadToDemo = () => {
                 false,
                 null,
                 handleToggleNadHover,
-                handleRightClick
+                handleRightClick,
+                true
             );
 
             document
                 .getElementById('svg-container-nad-multibus-vlnodes14')
-                ?.getElementsByTagName('svg')[0]
+                ?.querySelectorAll('div > svg')[0]
                 .setAttribute('style', 'border:2px; border-style:solid;');
         });
 
@@ -225,12 +229,13 @@ export const addNadToDemo = () => {
                 false,
                 null,
                 handleToggleNadHover,
-                handleRightClick
+                handleRightClick,
+                true
             );
 
             document
                 .getElementById('svg-container-nad-pst-hvdc')
-                ?.getElementsByTagName('svg')[0]
+                ?.querySelectorAll('div > svg')[0]
                 .setAttribute('style', 'border:2px; border-style:solid;');
         });
 
@@ -252,12 +257,13 @@ export const addNadToDemo = () => {
                 false,
                 null,
                 handleToggleNadHover,
-                handleRightClick
+                handleRightClick,
+                true
             );
 
             document
                 .getElementById('svg-container-nad-threewt-dl-ub')
-                ?.getElementsByTagName('svg')[0]
+                ?.querySelectorAll('div > svg')[0]
                 .setAttribute('style', 'border:2px; border-style:solid;');
         });
 
@@ -279,12 +285,13 @@ export const addNadToDemo = () => {
                 false,
                 null,
                 handleToggleNadHover,
-                handleRightClick
+                handleRightClick,
+                true
             );
 
             document
                 .getElementById('svg-container-nad-partial-network')
-                ?.getElementsByTagName('svg')[0]
+                ?.querySelectorAll('div > svg')[0]
                 .setAttribute('style', 'border:2px; border-style:solid;');
         });
 
@@ -310,11 +317,12 @@ export const addNadToDemo = () => {
                 enableLevelOfDetail,
                 null,
                 handleToggleNadHover,
-                handleRightClick
+                handleRightClick,
+                true
             );
 
             svgContainerNadPegase
-                ?.getElementsByTagName('svg')[0]
+                ?.querySelectorAll('div > svg')[0]
                 .setAttribute('style', 'border:2px; border-style:solid;');
 
             svgContainerNadPegase?.insertAdjacentHTML(

--- a/demo/src/diagram-viewers/add-diagrams.ts
+++ b/demo/src/diagram-viewers/add-diagrams.ts
@@ -65,8 +65,8 @@ export const addNadToDemo = () => {
 
             document
                 .getElementById('svg-container-nad')
-                ?.querySelectorAll('div > svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.querySelector('#svg-container > svg')
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
 
             // add range slider to update branch labels
             const branchLabelsSlider = document.createElement('input');
@@ -132,8 +132,8 @@ export const addNadToDemo = () => {
 
             document
                 .getElementById('svg-container-nad-no-moving')
-                ?.querySelectorAll('div > svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.querySelector('#svg-container > svg')
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 
     fetch(NadSvgMultibusVLNodesExample)
@@ -160,8 +160,8 @@ export const addNadToDemo = () => {
 
             document
                 .getElementById('svg-container-nad-multibus-vlnodes')
-                ?.querySelectorAll('div > svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.querySelector('#svg-container > svg')
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
 
             // add button to update branch labels
             const branchLabels = '[{"branchId": "L7-5-0", "value1": 609, "value2": -611}]';
@@ -207,8 +207,8 @@ export const addNadToDemo = () => {
 
             document
                 .getElementById('svg-container-nad-multibus-vlnodes14')
-                ?.querySelectorAll('div > svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.querySelector('#svg-container > svg')
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 
     fetch(NadSvgPstHvdcExample)
@@ -235,8 +235,8 @@ export const addNadToDemo = () => {
 
             document
                 .getElementById('svg-container-nad-pst-hvdc')
-                ?.querySelectorAll('div > svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.querySelector('#svg-container > svg')
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 
     fetch(NadSvgThreeWTDanglingLineUnknownBusExample)
@@ -263,8 +263,8 @@ export const addNadToDemo = () => {
 
             document
                 .getElementById('svg-container-nad-threewt-dl-ub')
-                ?.querySelectorAll('div > svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.querySelector('#svg-container > svg')
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 
     fetch(NadSvgPartialNetworkExample)
@@ -291,8 +291,8 @@ export const addNadToDemo = () => {
 
             document
                 .getElementById('svg-container-nad-partial-network')
-                ?.querySelectorAll('div > svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.querySelector('#svg-container > svg')
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
         });
 
     const enableLevelOfDetail: boolean =
@@ -322,8 +322,8 @@ export const addNadToDemo = () => {
             );
 
             svgContainerNadPegase
-                ?.querySelectorAll('div > svg')[0]
-                .setAttribute('style', 'border:2px; border-style:solid;');
+                ?.querySelector('#svg-container > svg')
+                ?.setAttribute('style', 'border:2px; border-style:solid;');
 
             svgContainerNadPegase?.insertAdjacentHTML(
                 'afterbegin',

--- a/src/components/network-area-diagram-viewer/diagram-metadata.ts
+++ b/src/components/network-area-diagram-viewer/diagram-metadata.ts
@@ -20,6 +20,7 @@ export interface LayoutParametersMetadata {
 }
 
 export interface SvgParametersMetadata {
+    diagramPadding: DiagramPaddingMetadata;
     voltageLevelCircleRadius: number;
     interAnnulusSpace: number;
     transformerCircleRadius: number;
@@ -36,6 +37,13 @@ export interface SvgParametersMetadata {
     powerValuePrecision: number;
     currentValuePrecision: number;
     insertNameDesc: boolean;
+}
+
+export interface DiagramPaddingMetadata {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
 }
 
 export interface BusNodeMetadata {

--- a/src/components/network-area-diagram-viewer/diagram-utils.test.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.test.ts
@@ -9,6 +9,7 @@
 import * as DiagramUtils from './diagram-utils';
 import { EdgeMetadata, BusNodeMetadata, NodeMetadata, TextNodeMetadata } from './diagram-metadata';
 import { SVG, Point } from '@svgdotjs/svg.js';
+import { SvgParameters } from './svg-parameters';
 
 test('getFormattedValue', () => {
     expect(DiagramUtils.getFormattedValue(12)).toBe('12.00');
@@ -474,6 +475,78 @@ test('getRightClickableElementData', () => {
     expect(elementData?.svgId).toBe('16');
     expect(elementData?.equipmentId).toBe('T4-1-0');
     expect(elementData?.type).toBe(DiagramUtils.EdgeType[DiagramUtils.EdgeType.TWO_WINDINGS_TRANSFORMER]);
+});
+
+test('getViewBox', () => {
+    const nodes: NodeMetadata[] = [
+        {
+            svgId: '0',
+            equipmentId: 'VL1',
+            x: -500.0,
+            y: 0.0,
+        },
+        {
+            svgId: '1',
+            equipmentId: 'VL2',
+            x: 0,
+            y: -500.0,
+        },
+        {
+            svgId: '2',
+            equipmentId: 'VL3',
+            x: 500.0,
+            y: 0.0,
+        },
+        {
+            svgId: '3',
+            equipmentId: 'VL4',
+            x: 0,
+            y: 500.0,
+        },
+    ];
+    const textNodes: TextNodeMetadata[] = [
+        {
+            svgId: '0-textnode',
+            equipmentId: 'VL1',
+            vlNode: '0',
+            shiftX: 100.0,
+            shiftY: -40.0,
+            connectionShiftX: 100.0,
+            connectionShiftY: -15.0,
+        },
+        {
+            svgId: '1-textnode',
+            equipmentId: 'VL2',
+            vlNode: '1',
+            shiftX: 100.0,
+            shiftY: -40.0,
+            connectionShiftX: 100.0,
+            connectionShiftY: -15.0,
+        },
+        {
+            svgId: '2-textnode',
+            equipmentId: 'VL3',
+            vlNode: '2',
+            shiftX: 100.0,
+            shiftY: -40.0,
+            connectionShiftX: 100.0,
+            connectionShiftY: -15.0,
+        },
+        {
+            svgId: '3-textnode',
+            equipmentId: 'VL4',
+            vlNode: '3',
+            shiftX: 100.0,
+            shiftY: -40.0,
+            connectionShiftX: 100.0,
+            connectionShiftY: -15.0,
+        },
+    ];
+    const viewBox = DiagramUtils.getViewBox(nodes, textNodes, new SvgParameters(undefined));
+    expect(viewBox.x).toBe(-700);
+    expect(viewBox.y).toBe(-740);
+    expect(viewBox.width).toBe(1700);
+    expect(viewBox.height).toBe(1500);
 });
 
 function getSvgNode(): SVGGraphicsElement {

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -674,8 +674,9 @@ function getButton(svg: string, title: string): HTMLButtonElement {
     button.style.height = '25px';
     button.style.width = '25px';
     button.style.marginRight = '1px';
-    button.style.marginLeft = '3px';
-    button.style.marginTop = '3px';
+    button.style.marginLeft = '1px';
+    button.style.marginTop = '1px';
+    button.style.marginBottom = '1px';
     button.style.padding = '0px';
     button.style.border = 'none';
     return button;

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -679,12 +679,15 @@ function getButton(svg: string, title: string): HTMLButtonElement {
     button.style.marginBottom = '1px';
     button.style.padding = '0px';
     button.style.border = 'none';
+    button.style.display = 'flex';
+    button.style.alignItems = 'center';
+    button.style.justifyContent = 'center';
     return button;
 }
 
 export function getZoomToFitButton(): HTMLButtonElement {
     return getButton(
-        '<svg xmlns="http://www.w3.org/2000/svg" height="15px" viewBox="0 0 32 32" width="15px" fill="#5f6368"><path d="M21.4479,20A10.856,10.856,0,0,0,24,13,11,11,0,1,0,13,24a10.856,10.856,0,0,0,7-2.5521L27.5859,29,29,27.5859ZM13,22a9,9,0,1,1,9-9A9.01,9.01,0,0,1,13,22Z"/><path d="M10,12H8V10a2.0023,2.0023,0,0,1,2-2h2v2H10Z"/><path d="M18,12H16V10H14V8h2a2.0023,2.0023,0,0,1,2,2Z"/><path d="M12,18H10a2.0023,2.0023,0,0,1-2-2V14h2v2h2Z"/><path d="M16,18H14V16h2V14h2v2A2.0023,2.0023,0,0,1,16,18Z"/></svg>',
+        '<svg xmlns="http://www.w3.org/2000/svg" height="15px" viewBox="0 -960 960 960" width="15px" fill="#5f6368"><path d="M200-120q-33 0-56.5-23.5T120-200v-160h80v160h160v80H200Zm400 0v-80h160v-160h80v160q0 33-23.5 56.5T760-120H600ZM120-600v-160q0-33 23.5-56.5T200-840h160v80H200v160h-80Zm640 0v-160H600v-80h160q33 0 56.5 23.5T840-760v160h-80Z"/></svg>',
         'Zoom to fit'
     );
 }

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -55,6 +55,9 @@ const EdgeTypeMapping: { [key: string]: EdgeType } = {
     ThreeWtEdge: EdgeType.THREE_WINDINGS_TRANSFORMER,
 };
 
+const TEXT_BOX_WIDTH_DEFAULT = 200.0;
+const TEXT_BOX_HEIGHT_DEFAULT = 100.0;
+
 // format number to string
 export function getFormattedValue(value: number): string {
     return value.toFixed(2);
@@ -647,9 +650,9 @@ export function getViewBox(
         const node = nodesMap.get(textNode.equipmentId);
         if (node !== undefined) {
             size.minX = Math.min(size.minX, node.x + textNode.shiftX);
-            size.maxX = Math.max(size.maxX, node.x + textNode.shiftX + svgParameters.getTextBoxWidth());
+            size.maxX = Math.max(size.maxX, node.x + textNode.shiftX + TEXT_BOX_WIDTH_DEFAULT);
             size.minY = Math.min(size.minY, node.y + textNode.shiftY);
-            size.maxY = Math.max(size.maxY, node.y + textNode.shiftY + svgParameters.getTextBoxHeight());
+            size.maxY = Math.max(size.maxY, node.y + textNode.shiftY + TEXT_BOX_HEIGHT_DEFAULT);
         }
     });
     return {

--- a/src/components/network-area-diagram-viewer/diagram-utils.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.ts
@@ -677,6 +677,7 @@ function getButton(svg: string, title: string): HTMLButtonElement {
     button.style.marginLeft = '1px';
     button.style.marginTop = '1px';
     button.style.marginBottom = '1px';
+    button.style.borderRadius = '5px';
     button.style.padding = '0px';
     button.style.border = 'none';
     button.style.display = 'flex';

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.test.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.test.ts
@@ -28,7 +28,8 @@ describe('Test network-area-diagram-viewer', () => {
             false,
             null,
             null,
-            null
+            null,
+            false
         );
 
         nad.moveNodeToCoordinates('', 0, 0);

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -129,6 +129,7 @@ export class NetworkAreaDiagramViewer {
     ) {
         this.container = container;
         this.svgDiv = document.createElement('div');
+        this.svgDiv.id = 'svg-container';
         this.svgContent = svgContent;
         this.diagramMetadata = diagramMetadata;
         this.width = 0;
@@ -308,13 +309,19 @@ export class NetworkAreaDiagramViewer {
         // clear the previous svg in div element before replacing
         this.container.innerHTML = '';
 
-        // add buttons bar
+        // add nad viewer div
+        const nadViewerDiv = document.createElement('div');
+        nadViewerDiv.id = 'nad-viewer';
+        nadViewerDiv.style.position = 'relative';
+        this.container.appendChild(nadViewerDiv);
+
+        // add buttons bar div
         if (addButtons) {
-            this.container.appendChild(this.getButtonsBar());
+            nadViewerDiv.appendChild(this.getButtonsBar());
         }
 
         // add svg div
-        this.container.appendChild(this.svgDiv);
+        nadViewerDiv.appendChild(this.svgDiv);
 
         // set dimensions
         this.setOriginalWidth(dimensions.width);
@@ -432,9 +439,12 @@ export class NetworkAreaDiagramViewer {
 
     private getButtonsBar(): HTMLDivElement {
         const buttonsDiv = document.createElement('div');
-        buttonsDiv.style.display = 'flex';
+        buttonsDiv.id = 'buttons-bars';
+        buttonsDiv.style.display = 'inline-grid';
         buttonsDiv.style.alignItems = 'center';
         buttonsDiv.style.position = 'absolute';
+        buttonsDiv.style.left = '3px';
+        buttonsDiv.style.bottom = '7px';
         buttonsDiv.style.zIndex = '2';
 
         const zoomToFitButton = DiagramUtils.getZoomToFitButton();

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -421,7 +421,7 @@ export class NetworkAreaDiagramViewer {
         }
         if (this.onRightClickCallback != null && hasMetadata) {
             // fill empty branch elements: two windings transformers
-            const emptyElements: NodeListOf<SVGGraphicsElement> = this.container.querySelectorAll(
+            const emptyElements: NodeListOf<SVGGraphicsElement> = this.svgDiv.querySelectorAll(
                 '.nad-branch-edges .nad-winding'
             );
             emptyElements.forEach((emptyElement) => {

--- a/src/components/network-area-diagram-viewer/svg-parameters.ts
+++ b/src/components/network-area-diagram-viewer/svg-parameters.ts
@@ -20,6 +20,13 @@ const EdgeInfoEnumMapping: { [key: string]: EdgeInfoEnum } = {
     CURRENT: EdgeInfoEnum.CURRENT,
 };
 
+type DiagramPadding = {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+};
+
 export class SvgParameters {
     static readonly VOLTAGE_LEVEL_CIRCLE_RADIUS_DEFAULT = 30.0;
     static readonly INTER_ANNULUS_SPACE_DEFAULT = 5.0;
@@ -36,6 +43,12 @@ export class SvgParameters {
     static readonly EDGE_INFO_DISPLAYED_DEFAULT = EdgeInfoEnum.ACTIVE_POWER;
     static readonly POWER_VALUE_PRECISION_RADIUS_DEFAULT = 0;
     static readonly CURRENT_VALUE_PRECISION_DEFAULT = 0;
+    static readonly DIAGRAM_PADDING_LEFT_DEFAULT = 200.0;
+    static readonly DIAGRAM_PADDING_TOP_DEFAULT = 200.0;
+    static readonly DIAGRAM_PADDING_RIGHT_DEFAULT = 200.0;
+    static readonly DIAGRAM_PADDING_BOTTON_DEFAULT = 200.0;
+    static readonly TEXT_BOX_WIDTH_DEFAULT = 200.0;
+    static readonly TEXT_BOX_HEIGHT_DEFAULT = 100.0;
 
     svgParametersMetadata: SvgParametersMetadata | undefined;
 
@@ -110,5 +123,22 @@ export class SvgParameters {
 
     public getCurrentValuePrecision(): number {
         return this.svgParametersMetadata?.currentValuePrecision ?? SvgParameters.CURRENT_VALUE_PRECISION_DEFAULT;
+    }
+
+    public getDiagramPadding(): DiagramPadding {
+        return {
+            left: this.svgParametersMetadata?.diagramPadding.left ?? SvgParameters.DIAGRAM_PADDING_LEFT_DEFAULT,
+            top: this.svgParametersMetadata?.diagramPadding.top ?? SvgParameters.DIAGRAM_PADDING_TOP_DEFAULT,
+            right: this.svgParametersMetadata?.diagramPadding.right ?? SvgParameters.DIAGRAM_PADDING_RIGHT_DEFAULT,
+            bottom: this.svgParametersMetadata?.diagramPadding.bottom ?? SvgParameters.DIAGRAM_PADDING_BOTTON_DEFAULT,
+        };
+    }
+
+    public getTextBoxWidth(): number {
+        return SvgParameters.TEXT_BOX_WIDTH_DEFAULT;
+    }
+
+    public getTextBoxHeight(): number {
+        return SvgParameters.TEXT_BOX_HEIGHT_DEFAULT;
     }
 }

--- a/src/components/network-area-diagram-viewer/svg-parameters.ts
+++ b/src/components/network-area-diagram-viewer/svg-parameters.ts
@@ -47,8 +47,6 @@ export class SvgParameters {
     static readonly DIAGRAM_PADDING_TOP_DEFAULT = 200.0;
     static readonly DIAGRAM_PADDING_RIGHT_DEFAULT = 200.0;
     static readonly DIAGRAM_PADDING_BOTTON_DEFAULT = 200.0;
-    static readonly TEXT_BOX_WIDTH_DEFAULT = 200.0;
-    static readonly TEXT_BOX_HEIGHT_DEFAULT = 100.0;
 
     svgParametersMetadata: SvgParametersMetadata | undefined;
 
@@ -132,13 +130,5 @@ export class SvgParameters {
             right: this.svgParametersMetadata?.diagramPadding.right ?? SvgParameters.DIAGRAM_PADDING_RIGHT_DEFAULT,
             bottom: this.svgParametersMetadata?.diagramPadding.bottom ?? SvgParameters.DIAGRAM_PADDING_BOTTON_DEFAULT,
         };
-    }
-
-    public getTextBoxWidth(): number {
-        return SvgParameters.TEXT_BOX_WIDTH_DEFAULT;
-    }
-
-    public getTextBoxHeight(): number {
-        return SvgParameters.TEXT_BOX_HEIGHT_DEFAULT;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
feature

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [ ] No

**What is the current behavior?**
In network area diagram viewer there is no functionality to automatically resize the SVG in order to fit it in the window


**What is the new behavior (if this is a feature change)?**
In network area diagram viewer there is a functionality and a button to automatically resize the SVG in order to fit it in the window


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
the constructor of the NetworkAreaDiagramViewer has an additional parameter: the flag for enabling the visualization of the button.
The demo/src/diagram-viewers/add-diagrams.js file has been changed for including this new parameter