### PR TITLE
Fix MUI imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
                 "@danmarshall/deckgl-typings": "^4.9.28",
                 "@mui/icons-material": "^5.15.14",
                 "@mui/material": "^5.15.14",
-                "@mui/system": "^5.15.14",
                 "@types/eslint": "^7.29.0",
                 "@types/eslint-config-prettier": "^6.11.3",
                 "@types/eslint-plugin-prettier": "^3.1.3",
@@ -66,7 +65,6 @@
                 "@emotion/styled": "^11.11.5",
                 "@mui/icons-material": "^5.15.14",
                 "@mui/material": "^5.15.14",
-                "@mui/system": "^5.15.14",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-intl": "^6.6.4"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^5.15.14",
         "@mui/material": "^5.15.14",
-        "@mui/system": "^5.15.14",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-intl": "^6.6.4"
@@ -61,7 +60,6 @@
         "@danmarshall/deckgl-typings": "^4.9.28",
         "@mui/icons-material": "^5.15.14",
         "@mui/material": "^5.15.14",
-        "@mui/system": "^5.15.14",
         "@types/eslint": "^7.29.0",
         "@types/eslint-config-prettier": "^6.11.3",
         "@types/eslint-plugin-prettier": "^3.1.3",

--- a/src/components/network-map-viewer/network/network-map.tsx
+++ b/src/components/network-map-viewer/network/network-map.tsx
@@ -19,16 +19,14 @@ import {
     useRef,
     useState,
 } from 'react';
-import { Box, decomposeColor } from '@mui/system';
+import { Box, Button, type ButtonProps, decomposeColor, useTheme } from '@mui/material';
 import { MapboxOverlay, type MapboxOverlayProps } from '@deck.gl/mapbox';
 import { Replay } from '@mui/icons-material';
-import { Button, type ButtonProps, useTheme } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import { Map, type MapProps, type MapRef, NavigationControl, useControl, type ViewState } from 'react-map-gl';
 import type { Feature, Polygon } from 'geojson';
 import { type Layer, type PickingInfo } from 'deck.gl';
 import type MapboxDraw from '@mapbox/mapbox-gl-draw';
-//import type { MjolnirGestureEvent } from 'mjolnir.js';
 import { getNominalVoltageColor } from '../../../utils/colors';
 import { useNameOrId } from '../utils/equipmentInfosHandler';
 import { GeoData } from './geo-data';

--- a/src/components/network-map-viewer/utils/loader-with-overlay.tsx
+++ b/src/components/network-map-viewer/utils/loader-with-overlay.tsx
@@ -5,9 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { CircularProgress, CircularProgressProps, SxProps } from '@mui/material';
+import { Box, CircularProgress, type CircularProgressProps, type SxProps, type Theme } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
-import { Box, Theme } from '@mui/system';
 
 export type LoaderWithOverlayProps = {
     color: CircularProgressProps['color'];


### PR DESCRIPTION
We currently use Material-UI, not raw components.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [ ] ~Docs have been added / updated (for bug fixes / features)~


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
We currently use Material-UI components, not the underlying components that does not manage MaterialUI styles.  
_For the note it's caused by the IDE auto-import._

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
No change.


**What is the new behavior (if this is a feature change)?**
No change.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**~If yes, please check if the following requirements are fulfilled~**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] ~The *Breaking Change* or *Deprecated* label has been added~
- [ ] ~The migration steps are described in the following section~

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
None.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Nope.