### PR TITLE
Remove outdated webpack/chokidar inotify watcher maxlimit bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,6 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: 22
-            - name: FixForNodeWarnings
-              run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
             - name: Build
               run: |


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
chore


**What is the current behavior?**
<!-- You can also link to an open issue here -->
useless inotify workaround


**What is the new behavior (if this is a feature change)?**
no more workaround, less code


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Vite doesn't use webpack/chokidar, not even sure if it was needed with the intial build system using parcel. It was probably just copy pasted in 7769c8806 over from our other older projects using nwb a long time ago
