### PR TITLE
Cleanup gitignore, use the same as other projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,9 @@
 # dependencies
 /node_modules
 
-# distribution
+# production
 /dist
 /powsybl-network-viewer-*.tgz
-
-# distrib for demo
-/output
 
 # webstorm
 /.idea
@@ -14,14 +11,5 @@
 # vscode
 /.vscode
 
-# parcel
-/.parcel-cache
-
-# demo
-/demo/node_modules
-/demo/build
-/demo/dist
-
-# lcov reporst
+# jest
 /coverage
-

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@
 # vscode
 /.vscode
 
+# vite
+/vite.config.ts-timestamp-*
+
 # jest
 /coverage


### PR DESCRIPTION
Most of it is leftover from the parcel build.
Fix typo reporst and name it like in our other projects.
add vite.config.ts-timestamp like in our other vite 6 migrations

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
chore


**What is the current behavior?**
<!-- You can also link to an open issue here -->
leftover and typos in gitignore


**What is the new behavior (if this is a feature change)?**
cleaned gitignore


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
