### PR TITLE
fixes onRightClickCallback coords computation

### DIFF
--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -1904,7 +1904,6 @@ export class NetworkAreaDiagramViewer {
         if (!elementData) {
             return;
         }
-        this.ctm = this.svgDraw?.node.getScreenCTM();
         const mousePosition: Point = this.getMousePosition(event);
         this.onRightClickCallback?.(elementData.svgId, elementData.equipmentId, elementData.type, mousePosition);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->

issue with the NAD right-click callback logic:   events coordinates are returned as  SVG document space coordinates in the related callback.
However, hover callback coordinates vary depending on previous right-click interactions with the diagram nodes. After a right click, the coordinates are returned as SVG document space coordinates. Then, after other interactions with the NAD elements,  e.g. dragging a node, the values are returned as screen coordinates.

This  behavior can be seen in the demo, by enabling the Javascript console and looking at the logged coordinates: hover on a line, right click on a node,  check the coordinates by hovering again  on the line.

**What is the new behavior (if this is a feature change)?**
values are consistently returned as screen coordinates, both in the hover and in right-click callbacks.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
