### PR TITLE
[sld-viewer] hovering callback for all equipments

### DIFF
--- a/src/components/single-line-diagram-viewer/single-line-diagram-viewer.ts
+++ b/src/components/single-line-diagram-viewer/single-line-diagram-viewer.ts
@@ -573,13 +573,7 @@ export class SingleLineDiagramViewer {
     }
 
     private addEquipmentsPopover() {
-        const equipmentsWithPopover = ['LINE', 'TWO_WINDINGS_TRANSFORMER', 'PHASE_SHIFT_TRANSFORMER'];
-
-        // handling the hover on the equipments
-        const svgEquipments = this.svgMetadata?.nodes.filter((node) =>
-            equipmentsWithPopover.includes(node.componentType)
-        );
-        svgEquipments?.forEach((equipment) => {
+        this.svgMetadata?.nodes?.forEach((equipment) => {
             const svgEquipment = this.container?.querySelector('#' + equipment.id);
             svgEquipment?.addEventListener('mouseover', (event) => {
                 const equipmentType =

--- a/src/components/single-line-diagram-viewer/single-line-diagram-viewer.ts
+++ b/src/components/single-line-diagram-viewer/single-line-diagram-viewer.ts
@@ -576,11 +576,7 @@ export class SingleLineDiagramViewer {
         this.svgMetadata?.nodes?.forEach((equipment) => {
             const svgEquipment = this.container?.querySelector('#' + equipment.id);
             svgEquipment?.addEventListener('mouseover', (event) => {
-                const equipmentType =
-                    equipment.componentType === 'PHASE_SHIFT_TRANSFORMER'
-                        ? 'TWO_WINDINGS_TRANSFORMER'
-                        : equipment.componentType;
-                this.onToggleHoverCallback?.(true, event.currentTarget, equipment.equipmentId, equipmentType);
+                this.onToggleHoverCallback?.(true, event.currentTarget, equipment.equipmentId, equipment.componentType);
             });
             svgEquipment?.addEventListener('mouseout', () => {
                 this.onToggleHoverCallback?.(false, null, '', '');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)

**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the current behavior?**
Hovering callback is only called for sld-viewer for lines, two-winding transformers and phase-shift transformers (whose type is overridden by two-winding tranformer)

**What is the new behavior (if this is a feature change)?**
Hovering callback is called for sld-viewer for any node mentioned in the metadata. No type is overridden.

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
If you were using the sld-viewer component with a non-null onToggleHoverCallback, you will now need to be able to process other types than the only two which were previously sent (`TWO_WINDINGS_TRANSFORMER` and `LINE`)


**Other information**:
This feature allows user to have hovering tooltips over other equipments than the three mentionned.