### PR TITLE
fixup etalab network-map spurious proptypes error

### DIFF
--- a/src/components/network-map-viewer/network/network-map.tsx
+++ b/src/components/network-map-viewer/network/network-map.tsx
@@ -843,7 +843,7 @@ NetworkMap.propTypes = {
     geoData: PropTypes.instanceOf(GeoData),
     mapBoxToken: PropTypes.string,
     mapEquipments: PropTypes.instanceOf(MapEquipments),
-    mapLibrary: PropTypes.oneOf([CARTO, CARTO_NOLABEL, MAPBOX]),
+    mapLibrary: PropTypes.oneOf([CARTO, CARTO_NOLABEL, MAPBOX, ETALAB]),
     mapTheme: PropTypes.oneOf([LIGHT, DARK]),
 
     areFlowsValid: PropTypes.bool,


### PR DESCRIPTION
Warning: Failed prop type: Invalid prop `mapLibrary` of value `etalab` supplied to `ForwardRef`, expected one of ["carto","cartonolabel","mapbox"].

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
valid value etalab triggers a warning


**What is the new behavior (if this is a feature change)?**
no warning


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No