### PR TITLE
Fix(NetworkMap):  Error with global var `mapDrawerController` at DrawControl unmount

### DIFF
--- a/src/components/network-map-viewer/network/draw-control.ts
+++ b/src/components/network-map-viewer/network/draw-control.ts
@@ -5,17 +5,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
-import { useCallback } from 'react';
+import { forwardRef, useCallback, useImperativeHandle } from 'react';
 import { type ControlPosition, useControl } from 'react-map-gl/mapbox-legacy';
 
 // type has been removed from react-map-gl or mapbox-gl
 type EventedListener = (event?: unknown) => unknown;
-
-let mapDrawerController: MapboxDraw | undefined = undefined;
-
-export function getMapDrawer() {
-    return mapDrawerController;
-}
 
 const emptyFn = () => {};
 
@@ -35,19 +29,16 @@ export type DrawControlProps = ConstructorParameters<typeof MapboxDraw>[0] & {
     onDelete?: EventedListener;
 };
 
-export default function DrawControl(props: DrawControlProps) {
+export const DrawControl = forwardRef((props: DrawControlProps, ref) => {
     const { onDrawPolygonModeActive } = props;
     const onModeChange = useCallback(
         (e: { mode: DRAW_MODES }) => onDrawPolygonModeActive(e.mode),
         [onDrawPolygonModeActive]
     );
 
-    useControl<MapboxDraw>(
+    const mapDrawerController = useControl<MapboxDraw>(
         //onCreate
-        () => {
-            mapDrawerController = new MapboxDraw({ ...props });
-            return mapDrawerController;
-        },
+        () => new MapboxDraw({ ...props }),
         //on add
         ({ map }) => {
             map.on('draw.create', props.onCreate ?? emptyFn);
@@ -65,5 +56,9 @@ export default function DrawControl(props: DrawControlProps) {
         { position: props.position }
     );
 
+    useImperativeHandle(ref, () => mapDrawerController, [mapDrawerController]);
+
     return null;
-}
+});
+
+export default DrawControl;

--- a/src/components/network-map-viewer/network/network-map.tsx
+++ b/src/components/network-map-viewer/network/network-map.tsx
@@ -37,7 +37,7 @@ import type MapboxDraw from '@mapbox/mapbox-gl-draw';
 import { getNominalVoltageColor } from '../../../utils/colors';
 import { useNameOrId } from '../utils/equipmentInfosHandler';
 import { GeoData } from './geo-data';
-import DrawControl, { type DrawControlProps, getMapDrawer } from './draw-control';
+import DrawControl, { type DrawControlProps } from './draw-control';
 import LineLayer, { LineFlowColorMode, LineFlowMode, type LineLayerProps } from './line-layer';
 import { MapEquipments } from './map-equipments';
 import SubstationLayer from './substation-layer';
@@ -138,11 +138,6 @@ const INITIAL_CENTERED: Centered = {
 };
 
 const DEFAULT_LOCATE_SUBSTATION_ZOOM_LEVEL = 12;
-
-/** get polygon coordinates (features) or an empty object */
-function getPolygonFeatures() {
-    return getMapDrawer()?.getAll()?.features[0] ?? ({} as Record<string, never>);
-}
 
 type TooltipType = {
     equipmentId: string;
@@ -307,6 +302,12 @@ const NetworkMap = forwardRef<NetworkMapRef, NetworkMapProps>((rawProps, ref) =>
     }, [props.mapEquipments?.hvdcLines, props.mapEquipments?.tieLines, props.mapEquipments?.lines]);
 
     const divRef = useRef<HTMLDivElement>(null);
+    const drawControlRef = useRef<MapboxDraw | undefined>(undefined);
+
+    /** get polygon coordinates (features) or an empty object */
+    const getPolygonFeatures = () => {
+        return drawControlRef.current?.getAll()?.features[0] ?? ({} as Record<string, never>);
+    };
 
     const mToken = !props.mapBoxToken ? FALLBACK_MAPBOX_TOKEN : props.mapBoxToken;
 
@@ -752,11 +753,13 @@ const NetworkMap = forwardRef<NetworkMapRef, NetworkMapProps>((rawProps, ref) =>
             getSelectedLines,
             cleanDraw() {
                 //because deleteAll does not trigger a update of the polygonFeature callback
-                getMapDrawer()?.deleteAll();
+                drawControlRef.current?.deleteAll();
                 onPolygonChanged(getPolygonFeatures());
                 onDrawEvent(DRAW_EVENT.DELETE);
             },
-            getMapDrawer,
+            getMapDrawer() {
+                return drawControlRef.current;
+            },
             resetZoomAndPosition,
         }),
         [onPolygonChanged, resetZoomAndPosition, getSelectedSubstations, getSelectedLines, onDrawEvent]
@@ -816,6 +819,7 @@ const NetworkMap = forwardRef<NetworkMapRef, NetworkMapProps>((rawProps, ref) =>
                 {/* visualizePitch true makes the compass reset the pitch when clicked in addition to visualizing it */}
                 <NavigationControl visualizePitch={true} />
                 <DrawControl
+                    ref={drawControlRef}
                     position="bottom-left"
                     displayControlsDefault={false}
                     controls={{


### PR DESCRIPTION
Remove `getMapDrawer` from global scope and use an imperative handle instead

When NetworkMap unmount. mapDrawerController in global scope had a non consistent state.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**What kind of change does this PR introduce?**
Bug Fix



**What is the current behavior?**
If you unmount the `NetworkMap` component, you get a front error when using the `getMapDrawer` function. 



**What is the new behavior (if this is a feature change)?**
Remove `getMapDrawer` from the global scope and make it follow life cycle of components


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
