### PR TITLE
Fix NetworkMap refresh after `mapLibrary` prop change

### DIFF
--- a/src/components/network-map-viewer/network/network-map.tsx
+++ b/src/components/network-map-viewer/network/network-map.tsx
@@ -776,6 +776,7 @@ const NetworkMap = forwardRef<NetworkMapRef, NetworkMapProps>((rawProps, ref) =>
                 doubleClickZoom={false}
                 mapStyle={mapStyle}
                 styleDiffing={false}
+                key={mapLib.key} // to reset the map when the mapLib changes
                 // @ts-expect-error TODO TS2322: Type typeof mapboxgl is not assignable to type MapLib<Map>|Promise<MapLib<Map>>|undefined
                 mapLib={mapLib.mapLib}
                 mapboxAccessToken={mapLib.mapboxAccessToken}


### PR DESCRIPTION
Restore `key` prop for `Map` component to reset the map when the `mapLibrary` changes
it was removed in the following PR #123 
As specified in documentation :
https://visgl.github.io/react-map-gl/docs/api-reference/mapbox/map#other-options
> Note: props in this section are not reactive. They are only used once when the Map instance is constructed.
then `mapLib` prop is not reactive its change does not refresh the map.


Note:
I did'nt spread `mapLib` object content in JSX because of the following React warning :
```
Warning: A props object containing a "key" prop is being spread into JSX:
...
React keys must be passed directly to JSX without using spread:
...
```
Comments added in code.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When you change the value of the `mapLibrary` prop of `NetworkMap` it doesn't refresh the Map component


**What is the new behavior (if this is a feature change)?**
When you change the value of the `mapLibrary` prop of `NetworkMap` a new `mapLib` object is created which mainly set a different `key` as the previous one. This `key` is passed as JSX props to the `Map` component and force it to refresh.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No