### PR TITLE
Fix NetworkAreaDiagramViewer strange pan behaviour if `enableNodeInteraction` on

### DIFF
--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -380,7 +380,6 @@ export class NetworkAreaDiagramViewer {
                 if ((e as MouseEvent).button == 0) {
                     this.onMouseLeftUpOrLeave(e as MouseEvent);
                 }
-                this.resetMouseEventParams();
             });
         }
         if (hasMetadata) {
@@ -747,10 +746,12 @@ export class NetworkAreaDiagramViewer {
         if (this.isDragging) {
             // moving element
             this.onDragEnd();
+            this.resetMouseEventParams();
         } else if (this.selectedElement) {
             // selecting element
             const mousePosition = this.getMousePosition(mouseEvent);
             this.onSelectEnd(mousePosition);
+            this.resetMouseEventParams();
         }
     }
 


### PR DESCRIPTION
Issue introduced by #205 


**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
First pan works perfectly but after the first call to `resetMouseEventParams` at `mouseup or mouseleave` events then the next pan has an unexpected behaviour. 
Mouse cursor position on the svg at end of pan is different than the one at beginning of pan
This results to strange move gaps.

Zoom isn't concerned here
The bug didn't exist if `enableNodeInteraction` is `false`


**What is the new behavior (if this is a feature change)?**
Then we call `resetMouseEventParams` only when necessary, at element DnD or element selection
Pan is constantly OK, no more pan gaps and all.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
