### PR TITLE
Fix NetworkMap: Imperative API `getSelectedLines` complete return type

### DIFF
--- a/src/components/network-map-viewer/network/network-map.tsx
+++ b/src/components/network-map-viewer/network/network-map.tsx
@@ -50,7 +50,6 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 import {
     EQUIPMENT_TYPES,
-    type MapAnyLine,
     type MapAnyLineWithType,
     type MapEquipment,
     type MapHvdcLine,

--- a/src/components/network-map-viewer/network/network-map.tsx
+++ b/src/components/network-map-viewer/network/network-map.tsx
@@ -199,7 +199,7 @@ export type NetworkMapProps = {
 
 export type NetworkMapRef = {
     getSelectedSubstations: () => MapSubstation[];
-    getSelectedLines: () => MapAnyLine[];
+    getSelectedLines: () => MapAnyLineWithType[];
     cleanDraw: () => void;
     getMapDrawer: () => MapboxDraw | undefined;
     resetZoomAndPosition: () => void;
@@ -918,7 +918,7 @@ function getSubstationsInPolygon(
 
 function getSelectedLinesInPolygon(
     network: MapEquipments | undefined,
-    lines: MapAnyLine[],
+    lines: MapAnyLineWithType[],
     geoData: GeoData | undefined,
     polygonCoordinates: Polygon
 ) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Change the return type of  `getSelectedLines` int the imperative API of NetworkMap component to be more precise.
It was `MapAnyLineWithType` instead of `MapAnyLine`
it allow clients to get the `equipmentType` to distinguish between LINE, TIE_LINE and HVDC_LINE


**What is the current behavior?**
<!-- You can also link to an open issue here -->
return a type without `equipmentType` declaration


**What is the new behavior (if this is a feature change)?**
return a type with `equipmentType` declaration


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
