### PR TITLE
fixes NAD viewer constructor

### DIFF
--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -174,18 +174,18 @@ export class NetworkAreaDiagramViewer {
         this.height = 0;
         this.originalWidth = 0;
         this.originalHeight = 0;
+        this.enableDragInteraction = enableDragInteraction;
+        this.onMoveNodeCallback = onMoveNodeCallback;
+        this.onMoveTextNodeCallback = onMoveTextNodeCallback;
         this.onRightClickCallback = onRightClickCallback;
+        this.onSelectNodeCallback = onSelectNodeCallback;
+        this.onToggleHoverCallback = onToggleHoverCallback;
         if (zoomLevels != null) this.zoomLevels = zoomLevels;
         this.zoomLevels.sort((a, b) => b - a);
         this.init(minWidth, minHeight, maxWidth, maxHeight, enableLevelOfDetail, diagramMetadata !== null, addButtons);
         this.svgParameters = new SvgParameters(diagramMetadata?.svgParameters);
         this.layoutParameters = new LayoutParameters(diagramMetadata?.layoutParameters);
-        this.onMoveNodeCallback = onMoveNodeCallback;
-        this.onMoveTextNodeCallback = onMoveTextNodeCallback;
-        this.onSelectNodeCallback = onSelectNodeCallback;
-        this.onToggleHoverCallback = onToggleHoverCallback;
         this.previousMaxDisplayedSize = 0;
-        this.enableDragInteraction = enableDragInteraction;
     }
 
     private fixSvgContent(svgContent: string): string {


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

no

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->

parameters enableDragInteraction, onRightClickCallback, and onSelectNodeCallback can be set to enable the corresponding interactions :  nodes and text-nodes drag&drop, the right click on a node and nodes selection.
Currently, however, if I set  only the enableDragInteraction parameter to true  (leaving the other two to null) the drag interaction is not activated.
Same applies to the onSelectNodeCallback parameter. 
The problem is with  the  instance properties setting order in the constructorç this.enableDragInteraction  and this.onSelectNodeCallback are set after the init method is called

The patch fixes the correct properties settings order (i.e., so that the drag and the right click interactions can  be enabled independently)

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
