### PR TITLE
Remove lintOnStart from vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig((config) => ({
         svgr(), // works on every import with the pattern "**/*.svg?react"
         eslint({
             failOnWarning: config.mode !== 'development',
-            lintOnStart: true,
         }),
         dts({
             include: ['src'],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Vite config change.
Do not activate `lintOnStart`



**What is the current behavior?**
<!-- You can also link to an open issue here -->
`npm start` -> lint all files before starting and lint modified files individually at running 
`npm run build` -> lint all files before building


**What is the new behavior (if this is a feature change)?**
`npm start` -> do not lint all files before starting but lint modified files individually at running 
`npm run build` -> lint all files before build


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
