### PR TITLE
Clean vite watch scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "prepublishOnly": "$npm_execpath run build",
         "test": "jest",
         "test:coverage": "jest --coverage",
-        "start": "vite demo/ --open",
+        "start": "vite demo/ --config vite.config.ts --open",
         "lint": "eslint . --ext js,mjs,jsx,ts,mts,tsx --max-warnings 0",
         "lint:format": "prettier --check --cache .",
         "licenses-check": "license-checker --summary --excludePrivatePackages --production --onlyAllow \"$( jq -r .onlyAllow[] license-checker-config.json | tr '\n' ';')\" --excludePackages \"$( jq -r .excludePackages[] license-checker-config.json | tr '\n' ';')\""

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
         "prepublishOnly": "$npm_execpath run build",
         "test": "jest",
         "test:coverage": "jest --coverage",
-        "start": "vite demo/ --config vite.config.ts --open",
+        "start": "vite demo/ --config vite.config.ts",
+        "start:open": "vite demo/ --config vite.config.ts --open",
         "lint": "eslint . --ext js,mjs,jsx,ts,mts,tsx --max-warnings 0",
         "lint:format": "prettier --check --cache .",
         "licenses-check": "license-checker --summary --excludePrivatePackages --production --onlyAllow \"$( jq -r .onlyAllow[] license-checker-config.json | tr '\n' ';')\" --excludePackages \"$( jq -r .excludePackages[] license-checker-config.json | tr '\n' ';')\""

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     ],
     "scripts": {
         "postinstall": "rimraf -I -g ./node_modules/@types/deck.gl* ./node_modules/@types/luma.gl* ./node_modules/@types/math.gl* ./node_modules/@types/mapbox-gl",
-        "watch": "vite watch",
         "prebuild": "tsc",
         "build": "vite build",
+        "build:watch": "vite build --watch --mode=development",
         "prepublishOnly": "$npm_execpath run build",
         "test": "jest",
         "test:coverage": "jest --coverage",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig((config) => ({
         svgr(), // works on every import with the pattern "**/*.svg?react"
         eslint({
             failOnWarning: config.mode !== 'development',
-            lintOnStart: true,
         }),
         dts({
             include: ['src'],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
fix existing script `vite watch`


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`vite watch` run `vite serve` in the 'watch' directory (which doesn't exist)
`vite watch` doesn't use the vite config file at root level


**What is the new behavior (if this is a feature change)?**
`vite build --watch --mode=development` was the intended behaviour
It uses the root vite config file


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

