### PR TITLE
Add the option to get the MouseEvent in the SLD's onNextVoltageCallback

### DIFF
--- a/demo/src/diagram-viewers/add-diagrams.ts
+++ b/demo/src/diagram-viewers/add-diagrams.ts
@@ -384,7 +384,7 @@ export const addSldToDemo = () => {
                 600,
                 1200,
                 1200,
-                handleNextVL, //callback on the next voltage arrows
+                handleNextVLWithEvent, //callback on the next voltage arrows
                 handleSwitch, //callback on the breakers
                 handleFeeder, //callback on the feeders
                 handleBus, //callback on the buses
@@ -396,6 +396,13 @@ export const addSldToDemo = () => {
 
 const handleNextVL: OnNextVoltageCallbackType = (id: string) => {
     const msg = 'Clicked on navigation arrow, dest VL is ' + id;
+    console.log(msg);
+};
+
+const handleNextVLWithEvent: OnNextVoltageCallbackType = (id: string, event: MouseEvent) => {
+    const msg = event.ctrlKey
+        ? 'Clicked on CTRL and navigation arrow, dest VL is ' + id
+        : 'Clicked on navigation arrow, dest VL is ' + id;
     console.log(msg);
 };
 

--- a/src/components/single-line-diagram-viewer/single-line-diagram-viewer.ts
+++ b/src/components/single-line-diagram-viewer/single-line-diagram-viewer.ts
@@ -82,7 +82,7 @@ export interface SLDMetadata {
     layoutParams: unknown;
 }
 
-export type OnNextVoltageCallbackType = (nextVId: string) => void;
+export type OnNextVoltageCallbackType = (nextVId: string, event: MouseEvent) => void;
 
 export type OnBreakerCallbackType = (breakerId: string, open: boolean, switchElement: SVGElement | null) => void;
 
@@ -447,7 +447,7 @@ export class SingleLineDiagramViewer {
                 }
                 const meta = svgMetadata?.nodes.find((other) => other.id === element.id);
                 if (meta !== undefined && meta !== null) {
-                    this.onNextVoltageCallback?.(meta.nextVId);
+                    this.onNextVoltageCallback?.(meta.nextVId, event);
                 }
             });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**
When using the onNextVoltageCallback callback in a SLD, we can now get the MouseEvent that triggered it.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
