### PR TITLE
Inject arrows without sub <svg>

### DIFF
--- a/src/components/single-line-diagram-viewer/single-line-diagram-viewer.ts
+++ b/src/components/single-line-diagram-viewer/single-line-diagram-viewer.ts
@@ -42,9 +42,9 @@ const MIN_ZOOM_LEVEL_SUB = 0.1;
 const MIN_ZOOM_LEVEL_VL = 0.5;
 
 const ARROW_SVG =
-    '<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg"><path class="arrow" fill-rule="evenodd" clip-rule="evenodd" d="M16 24.0163L17.2358 25.3171L21.9837 20.5691L26.7317 25.3171L28 24.0163L21.9837 18L16 24.0163Z"/></svg>';
+    '<path class="arrow" fill-rule="evenodd" clip-rule="evenodd" d="M16 24.0163L17.2358 25.3171L21.9837 20.5691L26.7317 25.3171L28 24.0163L21.9837 18L16 24.0163Z"/>';
 const ARROW_HOVER_SVG =
-    '<svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg"><path class="arrow-hover" fill-rule="evenodd" clip-rule="evenodd" d="M22 35C29.1797 35 35 29.1797 35 22C35 14.8203 29.1797 9 22 9C14.8203 9 9 14.8203 9 22C9 29.1797 14.8203 35 22 35ZM17.2358 25.3171L16 24.0163L21.9837 18L28 24.0163L26.7317 25.3171L21.9837 20.5691L17.2358 25.3171Z"/>';
+    '<path class="arrow-hover" fill-rule="evenodd" clip-rule="evenodd" d="M22 35C29.1797 35 35 29.1797 35 22C35 14.8203 29.1797 9 22 9C14.8203 9 9 14.8203 9 22C9 29.1797 14.8203 35 22 35ZM17.2358 25.3171L16 24.0163L21.9837 18L28 24.0163L26.7317 25.3171L21.9837 20.5691L17.2358 25.3171Z"/>';
 
 export interface SLDMetadataNode {
     id: string;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No.



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
For Chromium browsers, in version 141, SLD arrows display is broken. The sub <svg> cointaining the arrrows are not interpreted the same way they were before. 


**What is the new behavior (if this is a feature change)?**
The sub <svg> are withdrawn and we straight inject the <path>. It fixes the display


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
