### PR TITLE
Fix : Use root folder vite.config for demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "prepublishOnly": "$npm_execpath run build",
         "test": "jest",
         "test:coverage": "jest --coverage",
-        "start": "vite demo/ --open",
+        "start": "vite demo/ --config vite.config.ts --open",
         "lint": "eslint . --ext js,mjs,jsx,ts,mts,tsx --max-warnings 0",
         "lint:format": "prettier --check --cache .",
         "licenses-check": "license-checker --summary --excludePrivatePackages --production --onlyAllow \"$( jq -r .onlyAllow[] license-checker-config.json | tr '\n' ';')\" --excludePackages \"$( jq -r .excludePackages[] license-checker-config.json | tr '\n' ';')\""


### PR DESCRIPTION
fix(): use root folder vite.config.ts for demo otherwise it looks for a config in demo/ folder which doesn't exist and then use the default one

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
fix for demo usage


**What is the current behavior?**
<!-- You can also link to an open issue here -->
when running `npm start` vite doesn't use the vite.config.ts file at root level because it looks for a config file into demo/ folder.


**What is the new behavior (if this is a feature change)?**
when running `npm start` vite use the vite.config.ts file at root level


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
