### PR TITLE
Add creation of SVG edges from diagram metadata in NAD SVG writer

### DIFF
--- a/src/components/network-area-diagram-viewer/diagram-utils.test.ts
+++ b/src/components/network-area-diagram-viewer/diagram-utils.test.ts
@@ -71,9 +71,13 @@ test('getPointAtDistanceWithAngle', () => {
 });
 
 test('getTransformerArrowMatrixString', () => {
-    expect(DiagramUtils.getTransformerArrowMatrixString(Math.PI / 4, new Point(60, 60), 20)).toBe(
-        '0.71,0.71,-0.71,0.71,60.00,17.57'
-    );
+    expect(
+        DiagramUtils.getTransformerArrowMatrixString(
+            [new Point(-215.57, -488.07), new Point(-191.64, -354.01)],
+            [new Point(-157.17, -160.87), new Point(-181.1, -294.94)],
+            20
+        )
+    ).toBe('0.18,0.98,-0.98,0.18,-162.11,-359.28');
 });
 
 test('getVoltageLevelCircleRadius', () => {

--- a/src/components/network-area-diagram-viewer/edge-router.ts
+++ b/src/components/network-area-diagram-viewer/edge-router.ts
@@ -34,6 +34,14 @@ export class EdgeRouter {
         return DiagramUtils.getAngle(halfEdgePoints[0], halfEdgePoints[1]);
     }
 
+    public getEdgePoints(edgeId: string, side: string): Point[] | undefined {
+        const egdesPoints = this.edgePoints[edgeId];
+        if (!egdesPoints) {
+            return undefined;
+        }
+        return side == '1' ? egdesPoints[0] : egdesPoints[1];
+    }
+
     private init() {
         const edgeGroups = this.groupEdges();
         this.storeGroupedEdges(edgeGroups.groupedEdges);
@@ -44,6 +52,9 @@ export class EdgeRouter {
         const groupedEdges: Record<string, EdgeMetadata[]> = {};
         const loopEdges: Record<string, EdgeMetadata[]> = {};
         this.diagramMetadata.edges.forEach((edge) => {
+            if (MetadataUtils.isThreeWtEdge(edge)) {
+                return;
+            }
             const isLoop = edge.node1 === edge.node2;
             const key = isLoop ? edge.node1 : MetadataUtils.getGroupedEdgesIndexKey(edge);
             const target = isLoop ? loopEdges : groupedEdges;

--- a/src/components/network-area-diagram-viewer/half-edge-utils.ts
+++ b/src/components/network-area-diagram-viewer/half-edge-utils.ts
@@ -12,6 +12,7 @@ import { BusNodeMetadata, DiagramMetadata, EdgeMetadata, NodeMetadata, PointMeta
 import {
     degToRad,
     getAngle,
+    getConverterStationPoints,
     getMidPosition,
     getPointAtDistance,
     getPointAtDistanceWithAngle,
@@ -62,15 +63,6 @@ export function getLabelData(halfEdge: HalfEdge, arrowLabelShift: number): [numb
     ];
 }
 
-// get the points of a converter station of an HVDC line edge
-function getConverterStationPoints(halfEdge: HalfEdge, converterStationWidth: number): [Point, Point] {
-    const halfWidth = converterStationWidth / 2;
-    const middlePoint = halfEdge.edgePoints.at(-1)!;
-    const point1 = getPointAtDistance(middlePoint, halfEdge.edgePoints.at(-2)!, halfWidth);
-    const point2 = getPointAtDistance(point1, middlePoint, converterStationWidth);
-    return [point1, point2];
-}
-
 // get the polyline of a converter station of an HVDC line edge
 export function getConverterStationPolyline(
     halfEdge1: HalfEdge | null,
@@ -78,10 +70,10 @@ export function getConverterStationPolyline(
     converterStationWidth: number
 ): string {
     if (halfEdge1) {
-        const points = getConverterStationPoints(halfEdge1, converterStationWidth);
+        const points = getConverterStationPoints(halfEdge1.edgePoints, converterStationWidth);
         return getFormattedPolyline(points);
     } else if (halfEdge2) {
-        const points = getConverterStationPoints(halfEdge2, converterStationWidth);
+        const points = getConverterStationPoints(halfEdge2.edgePoints, converterStationWidth);
         return getFormattedPolyline(points);
     } else {
         return ''; // should never occur

--- a/src/components/network-area-diagram-viewer/metadata-utils.ts
+++ b/src/components/network-area-diagram-viewer/metadata-utils.ts
@@ -364,3 +364,11 @@ function addBusNodeEdge(busNodeId: string, edge: EdgeMetadata, busNodeEdges: Map
     busEdgeGroup.push(edge);
     busNodeEdges.set(busNodeId, busEdgeGroup);
 }
+
+export function isThreeWtEdge(edge: EdgeMetadata): boolean {
+    const edgeType = getEdgeType(edge);
+    return (
+        edgeType == EdgeType.THREE_WINDINGS_TRANSFORMER ||
+        (edgeType == EdgeType.PHASE_SHIFT_TRANSFORMER && edge.node2 == edge.busNode2)
+    );
+}

--- a/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/src/components/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -1331,26 +1331,10 @@ export class NetworkAreaDiagramViewer {
         halfEdge1: HalfEdge | null,
         halfEdge2: HalfEdge | null
     ) {
-        let rotationAngle = 0;
-        let transformerCenter = new Point(0, 0);
-        if (halfEdge1) {
-            const start = halfEdge1.edgePoints.at(-2)!;
-            const end = halfEdge1.edgePoints.at(-1)!;
-            const shiftEnd = -1.5 * this.svgParameters.getTransformerCircleRadius();
-            rotationAngle = DiagramUtils.getAngle(start, end);
-            transformerCenter = DiagramUtils.getPointAtDistance(end, start, shiftEnd);
-        } else if (halfEdge2) {
-            const start = halfEdge2.edgePoints.at(-2)!;
-            const end = halfEdge2.edgePoints.at(-1)!;
-            const shiftEnd = -2 * this.svgParameters.getTransformerCircleRadius();
-            rotationAngle = DiagramUtils.getAngle(end, start);
-            transformerCenter = DiagramUtils.getPointAtDistance(end, start, shiftEnd);
-        }
-
         const arrowPath: SVGGraphicsElement | null = transformerElement.querySelector('path');
         const matrix: string = DiagramUtils.getTransformerArrowMatrixString(
-            rotationAngle,
-            transformerCenter,
+            halfEdge1?.edgePoints,
+            halfEdge2?.edgePoints,
             this.svgParameters.getTransformerCircleRadius()
         );
         arrowPath?.setAttribute('transform', 'matrix(' + matrix + ')');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
feature



**What is the current behavior?**
the SVG writer, that creates the NAD SVG starting from the diagram metadata, handles only voltage level nodes, and it does not create edges.



**What is the new behavior (if this is a feature change)?**
the SVG writer, that creates the NAD SVG starting from the diagram metadata, creates both voltage level nodes and edges


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
