### PR TITLE
Simplify fork drawing following latest diagram release when creating NAD SVG from metadata

### DIFF
--- a/src/components/network-area-diagram-viewer/edge-router.ts
+++ b/src/components/network-area-diagram-viewer/edge-router.ts
@@ -86,16 +86,8 @@ export class EdgeRouter {
     private storeGroupedEdges(edges: Record<string, EdgeMetadata[]>) {
         for (const edgeId in edges) {
             const groupedEdges = edges[edgeId];
-            if (groupedEdges.length == 1) {
-                this.storeHalfEdges(groupedEdges[0], 1, 0);
-            } else {
-                for (let iEdge = 0; iEdge < groupedEdges.length; iEdge++) {
-                    if (2 * iEdge + 1 == groupedEdges.length) {
-                        this.storeHalfEdges(groupedEdges[iEdge], 1, 0);
-                    } else {
-                        this.storeHalfEdges(groupedEdges[iEdge], groupedEdges.length, iEdge);
-                    }
-                }
+            for (let iEdge = 0; iEdge < groupedEdges.length; iEdge++) {
+                this.storeHalfEdges(groupedEdges[iEdge], groupedEdges.length, iEdge);
             }
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
feature



**What is the current behavior?**
In the SVG writer, when creating the NAD SVG starting from the diagram metadata, the middle edge of parallel edges is still created as in the previous diagram releases, with just 2 points for each half edge, and no forking point. 



**What is the new behavior (if this is a feature change)?**
In the SVG writer, when creating the NAD SVG starting from the diagram metadata, the middle edge of parallel edges is created according to the latest diagram release, with 3 points for each half edge, including the forking point. 


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No