### PR TITLE
[nad-viewer] Add text nodes and edges when creating SVG from diagram metadata

### DIFF
--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -1783,22 +1783,7 @@ export class NetworkAreaDiagramViewer {
             return;
         }
 
-        // compute legend edge start and end oints
-        const nodePoint = new Point(node.x, node.y);
-        const endTextEdge = new Point(node.x + textNode.connectionShiftX, node.y + textNode.connectionShiftY);
-        const nbNeighbours = busNodes !== undefined && busNodes.length > 1 ? busNodes.length - 1 : 0;
-        const voltageLevelCircleRadius = DiagramUtils.getVoltageLevelCircleRadius(
-            nbNeighbours,
-            node?.fictitious,
-            this.svgParameters
-        );
-        const startTextEdge = DiagramUtils.getPointAtDistance(nodePoint, endTextEdge, voltageLevelCircleRadius);
-
-        //create the legend edge element in the DOM
-        const newLegendEdgeElement = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
-        newLegendEdgeElement.id = node?.legendEdgeSvgId ?? '';
-        const polyline = DiagramUtils.getFormattedPolyline([startTextEdge, endTextEdge]);
-        newLegendEdgeElement.setAttribute('points', polyline);
+        const newLegendEdgeElement = SvgUtils.createTextEdge(textNode, node, busNodes, this.svgParameters);
 
         this.textEdgesSection?.appendChild(newLegendEdgeElement);
         return newLegendEdgeElement;

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-utils.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-utils.ts
@@ -7,8 +7,16 @@
  */
 
 import { Point } from '@svgdotjs/svg.js';
-import { getAngle, getFormattedPoint } from './diagram-utils';
+import {
+    getAngle,
+    getFormattedPoint,
+    getFormattedPolyline,
+    getPointAtDistance,
+    getVoltageLevelCircleRadius,
+} from './diagram-utils';
 import { ElementType, ViewBox } from './diagram-types';
+import { BusNodeMetadata, NodeMetadata, TextNodeMetadata } from './diagram-metadata';
+import { SvgParameters } from './svg-parameters';
 
 // get the draggable element, if present,
 // from the element selected using the mouse
@@ -413,4 +421,58 @@ export function computeVisibleArea(
         width: vbox.width + dx * 2,
         height: vbox.height + dy * 2,
     };
+}
+
+export function createTextNode(
+    textNode: TextNodeMetadata,
+    node: NodeMetadata,
+    busNodes: BusNodeMetadata[]
+): HTMLElement {
+    const newTextElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+    newTextElement.style.position = 'absolute';
+    newTextElement.style.top = (node.y + textNode.shiftY).toFixed(0) + 'px';
+    newTextElement.style.left = (node.x + textNode.shiftX).toFixed(0) + 'px';
+    newTextElement.id = textNode.svgId;
+    newTextElement.classList.add('nad-label-box');
+
+    const newVlNameElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+    newVlNameElement.textContent = textNode.equipmentId;
+    newTextElement.appendChild(newVlNameElement);
+
+    for (const busNode of busNodes) {
+        const newBusDivElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+        newBusDivElement.classList.add('nad-bus-descr');
+
+        const newBusLegendElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'span');
+        newBusLegendElement.classList.add('nad-legend-square');
+        const textNode = document.createTextNode(busNode.legend ?? '');
+        newBusDivElement.appendChild(newBusLegendElement);
+        newBusDivElement.appendChild(textNode);
+
+        newTextElement.appendChild(newBusDivElement);
+    }
+
+    return newTextElement;
+}
+
+export function createTextEdge(
+    textNode: TextNodeMetadata,
+    node: NodeMetadata,
+    busNodes: BusNodeMetadata[],
+    svgParameters: SvgParameters
+): SVGPolylineElement {
+    // compute text edge start and end points
+    const nodePoint = new Point(node.x, node.y);
+    const endTextEdge = new Point(node.x + textNode.connectionShiftX, node.y + textNode.connectionShiftY);
+    const nbNeighbours = busNodes !== undefined && busNodes.length > 1 ? busNodes.length - 1 : 0;
+    const voltageLevelCircleRadius = getVoltageLevelCircleRadius(nbNeighbours, node.fictitious, svgParameters);
+    const startTextEdge = getPointAtDistance(nodePoint, endTextEdge, voltageLevelCircleRadius);
+
+    //create the text edge element
+    const newLegendEdgeElement = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+    newLegendEdgeElement.id = node.legendEdgeSvgId ?? '';
+    const polyline = getFormattedPolyline([startTextEdge, endTextEdge]);
+    newLegendEdgeElement.setAttribute('points', polyline);
+
+    return newLegendEdgeElement;
 }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
@@ -13,12 +13,15 @@ import { SvgParameters } from './svg-parameters';
 import * as MetadataUtils from './metadata-utils';
 import { EdgeRouter } from './edge-router';
 import { EdgeType } from './diagram-types';
+import * as SvgUtils from './svg-utils';
 
 export class SvgWriter {
     static readonly NODES_CLASS = 'nad-vl-nodes';
     static readonly BUS_CLASS = 'nad-busnode';
     static readonly EDGES_CLASS = 'nad-branch-edges';
     static readonly THREEWT_EDGES_CLASS = 'nad-3wt-edges';
+    static readonly TEXT_NODES_CLASS = 'nad-text-nodes';
+    static readonly TEXT_EDGES_CLASS = 'nad-text-edges';
     static readonly EDGE_CLASS = 'nad-edge-path';
     static readonly HVDC_EDGE_CLASS = 'nad-hvdc-edge';
     static readonly DANGLING_LINE_EDGE_CLASS = 'nad-dangling-line-edge';
@@ -53,6 +56,10 @@ export class SvgWriter {
         if (threeWtEdges && threeWtEdges.length > 0) {
             svg.appendChild(this.getThreeWtEdges(threeWtEdges));
         }
+        // add text nodes and edges
+        const textNodeAndEdges = this.getTextNodesAndEdges();
+        svg.appendChild(textNodeAndEdges.textEdges);
+        svg.appendChild(textNodeAndEdges.textNodes);
         return new XMLSerializer().serializeToString(xmlDoc);
     }
 
@@ -289,5 +296,28 @@ export class SvgWriter {
         polylineElement.classList.add(SvgWriter.EDGE_CLASS);
         polylineElement.setAttribute('points', DiagramUtils.getFormattedPolyline(points));
         return polylineElement;
+    }
+
+    private getTextNodesAndEdges(): { textNodes: SVGForeignObjectElement; textEdges: SVGGElement } {
+        // create text nodes foreignObject element
+        const textNodesForeignObject = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject');
+        textNodesForeignObject.setAttribute('height', '1');
+        textNodesForeignObject.setAttribute('width', '1');
+        textNodesForeignObject.classList.add(SvgWriter.TEXT_NODES_CLASS);
+        const textNodesDiv = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+        textNodesForeignObject.appendChild(textNodesDiv);
+        // create text edges g element
+        const gTextEdgesElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        gTextEdgesElement.classList.add(SvgWriter.TEXT_EDGES_CLASS);
+        // create text nodes and edges
+        this.diagramMetadata.textNodes.forEach((textNode) => {
+            const node = MetadataUtils.getNodeMetadata(textNode.vlNode, this.diagramMetadata);
+            if (node && !node.invisible) {
+                const busNodes = MetadataUtils.getBusNodesMetadata(node.svgId, this.diagramMetadata.busNodes);
+                textNodesDiv.appendChild(SvgUtils.createTextNode(textNode, node, busNodes));
+                gTextEdgesElement.appendChild(SvgUtils.createTextEdge(textNode, node, busNodes, this.svgParameters));
+            }
+        });
+        return { textNodes: textNodesForeignObject, textEdges: gTextEdgesElement };
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
feature



**What is the current behavior?**
When creating the SVG from diagram metadata, the SvgWriter does not create text nodes and text edges, only VL nodes and edges



**What is the new behavior (if this is a feature change)?**
When creating the SVG from diagram metadata, the SvgWriter creates also text nodes and text edges


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No