### PR TITLE
chore(ts): Update tsconfig to have a base, include baseUrl and paths for module resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ This library contains three viewers:
 The library is built with the Vite bundler.
 Node from v22+ is required to build with Vite.
 
-> **_Note:_**    
-A .nvmrc file is present in the repository, please run `nvm use` to use the expected NodeJS version.
+> **_Note:_**  
+> A .nvmrc file is present in the repository, please run `nvm use` to use the expected NodeJS version.
 
 ## Installation
 
 The library is split into 3 packages to accommodate different use cases:
 
 | Package                        | Description                                        |
-|--------------------------------|----------------------------------------------------|
+| ------------------------------ | -------------------------------------------------- |
 | `@powsybl/network-viewer`      | Full package with all viewers including NetworkMap |
 | `@powsybl/network-viewer-core` | Core viewers (NAD + SLD)                           |
 | `@powsybl/network-map-layers`  | Deck.gl layers for map integration                 |

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,18 +1,13 @@
 {
-    "extends": "../tsconfig.json",
+    "extends": "../tsconfig.base.json",
     "compilerOptions": {
-        "baseUrl": ".",
+        "outDir": "./dist",
+        "jsx": "react-jsx",
         "paths": {
-            "@powsybl/network-map-layers": ["../packages/network-map-layers/src"],
-            "@powsybl/network-viewer-core": ["../packages/network-viewer-core/src"],
+            "@powsybl/network-viewer-core": ["../packages/network-viewer-core/src/"],
+            "@powsybl/network-map-layers": ["../packages/network-map-layers/src/"],
             "@powsybl/network-viewer": ["../src"]
         }
     },
-    "include": [
-        "src",
-        "../src",
-        "../packages/network-map-layers/src",
-        "../packages/network-viewer-core/src",
-        "../vite-plugin-checker.d.ts"
-    ]
+    "include": ["src", "../src", "../packages/network-map-layers/src", "../packages/network-viewer-core/src"]
 }

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -13,7 +13,7 @@ const workspaceRoot = path.resolve(__dirname, '..');
 
 export default defineConfig((config) => ({
     root: __dirname,
-    plugins: [viteEslintChecker(config.isPreview, config.command, './tsconfig.json'), react()],
+    plugins: [viteEslintChecker(config.isPreview, config.command), react()],
     resolve: {
         alias: {
             // Use source files from the workspace packages during demo dev for HMR

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
             "version": "3.3.0-dev.0",
             "license": "MPL-2.0",
             "workspaces": [
-                "packages/network-map-layers",
-                "packages/network-viewer-core"
+                "packages/*"
             ],
             "dependencies": {
                 "@deck.gl/core": "~9.0.0",
@@ -67,7 +66,7 @@
                 "typescript": "^5.8.3",
                 "typescript-eslint": "^8.31.0",
                 "vite": "^6.2.2",
-                "vite-plugin-checker": "^0.9.1",
+                "vite-plugin-checker": "^0.12.0",
                 "vite-plugin-dts": "^4.5.3",
                 "vite-plugin-svgr": "^4.3.0"
             },
@@ -176,7 +175,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -1966,6 +1964,7 @@
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
             "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -2069,7 +2068,6 @@
             "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.0.41.tgz",
             "integrity": "sha512-GWZJ0tiLN6b4OsH299yoKv16BUfOydB9d3lDTYE+AHKXXfH/gL+T9dpDj2aUM+chkrzdoqy0F2iC6rbpZQk7ag==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@loaders.gl/core": "^4.2.0",
                 "@loaders.gl/images": "^4.2.0",
@@ -2094,7 +2092,6 @@
             "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.0.41.tgz",
             "integrity": "sha512-rvPAlKwv4seED1v+n+O+ACGjC9UI7nx/WF5PiSNFUcLqHsiC1QbAoiJ0t/SC2ox2BrrJgYOlPxdll892sC6eFg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@luma.gl/constants": "~9.0.27",
                 "@luma.gl/shadertools": "~9.0.27",
@@ -2111,7 +2108,6 @@
             "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.0.41.tgz",
             "integrity": "sha512-r+IR/ga+p2NZJeEvmKJch5BAHOJAcGnizZkFzvJh9MoEbkZm72ZxeFcGGslW4XXvmZ79h8cixDwMZJmmOYRcWw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@loaders.gl/images": "^4.2.0",
                 "@loaders.gl/schema": "^4.2.0",
@@ -2147,6 +2143,7 @@
             "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
             "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/runtime": "^7.18.3",
@@ -2165,13 +2162,15 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/cache": {
             "version": "11.14.0",
             "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
             "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.9.0",
                 "@emotion/sheet": "^1.4.0",
@@ -2184,13 +2183,15 @@
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
             "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
             "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.9.0"
             }
@@ -2199,7 +2200,8 @@
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
             "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/react": {
             "version": "11.14.0",
@@ -2231,6 +2233,7 @@
             "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
             "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/hash": "^0.9.2",
                 "@emotion/memoize": "^0.9.0",
@@ -2243,7 +2246,8 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
             "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/styled": {
             "version": "11.14.1",
@@ -2273,13 +2277,15 @@
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
             "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
             "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
@@ -2288,13 +2294,15 @@
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
             "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@emotion/weak-memoize": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
             "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.12",
@@ -2946,6 +2954,7 @@
             "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
             "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@formatjs/fast-memoize": "2.2.7",
                 "@formatjs/intl-localematcher": "0.6.2",
@@ -2958,6 +2967,7 @@
             "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
             "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.8.0"
             }
@@ -2967,6 +2977,7 @@
             "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
             "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@formatjs/ecma402-abstract": "2.3.6",
                 "@formatjs/icu-skeleton-parser": "1.8.16",
@@ -2978,6 +2989,7 @@
             "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
             "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@formatjs/ecma402-abstract": "2.3.6",
                 "tslib": "^2.8.0"
@@ -2988,6 +3000,7 @@
             "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-3.1.8.tgz",
             "integrity": "sha512-LWXgwI5zTMatvR8w8kCNh/priDTOF/ZssokMBHJ7ZWXFoYLVOYo0EJERD9Eajv+xsfQO1QkuAt77KWQ1OI4mOQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@formatjs/ecma402-abstract": "2.3.6",
                 "@formatjs/fast-memoize": "2.2.7",
@@ -3009,6 +3022,7 @@
             "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
             "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.8.0"
             }
@@ -3485,7 +3499,6 @@
             "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.3.4.tgz",
             "integrity": "sha512-cG0C5fMZ1jyW6WCsf4LoHGvaIAJCEVA/ioqKoYRwoSfXkOf+17KupK1OUQyUCw5XoRn+oWA1FulJQOYlXnb9Gw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@loaders.gl/loader-utils": "4.3.4",
                 "@loaders.gl/schema": "4.3.4",
@@ -3545,15 +3558,13 @@
             "version": "9.0.28",
             "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.0.28.tgz",
             "integrity": "sha512-mw3YwYfCbpCa8y28nNZGaJemprSkqthsunz0V79qpnMrFD3pOMIh+rw/hjQuqVW9ffmSXx+xY2bI8FT1YC8f7A==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@luma.gl/core": {
             "version": "9.0.28",
             "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.0.28.tgz",
             "integrity": "sha512-5PHSEO70o+bze7uax/2e5YTNUAqwcPXrABOvvxm+ihw+guWpqIHGt8wStoY2HKwmQhF8eT4f7nc762E/oyl4NA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@math.gl/types": "^4.0.0",
                 "@probe.gl/env": "^4.0.2",
@@ -3567,7 +3578,6 @@
             "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.0.28.tgz",
             "integrity": "sha512-EidAG/1Sgq0OeoyrebkcrC5TMvfK8ycIpSAjIRdi8hjwpHIoHFj5P3MWeApTZ1HV0DroxChzrxRCHYylI8svPQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@luma.gl/shadertools": "9.0.28",
                 "@math.gl/core": "^4.0.0",
@@ -3968,6 +3978,7 @@
             "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz",
             "integrity": "sha512-jbhwoQ1AY200PSSOrNXmrFCaSDSJWP7qk6urkTmIirvRXDROkqe+QwcLlUiw/PrREwsIF/vm3/dAXvjlMHF0RA==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mui-org"
@@ -4051,6 +4062,7 @@
             "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
             "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
                 "@mui/utils": "^5.17.1",
@@ -4078,6 +4090,7 @@
             "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.18.0.tgz",
             "integrity": "sha512-BN/vKV/O6uaQh2z5rXV+MBlVrEkwoS/TK75rFQ2mjxA7+NBo8qtTAOA4UaM0XeJfn7kh2wZ+xQw2HAx0u+TiBg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
                 "@emotion/cache": "^11.13.5",
@@ -4111,6 +4124,7 @@
             "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.18.0.tgz",
             "integrity": "sha512-ojZGVcRWqWhu557cdO3pWHloIGJdzVtxs3rk0F9L+x55LsUjcMUVkEhiF7E4TMxZoF9MmIHGGs0ZX3FDLAf0Xw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
                 "@mui/private-theming": "^5.17.1",
@@ -4151,6 +4165,7 @@
             "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.24.tgz",
             "integrity": "sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
             },
@@ -4165,6 +4180,7 @@
             "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.17.1.tgz",
             "integrity": "sha512-jEZ8FTqInt2WzxDV8bhImWBqeQRD99c/id/fq83H0ER9tFl+sfZlaAoCdznGvbSQQ9ividMxqSV2c7cC1vBcQg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.23.9",
                 "@mui/types": "~7.2.15",
@@ -4208,6 +4224,7 @@
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -4666,7 +4683,6 @@
             "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "json-schema-traverse": "^1.0.0",
@@ -5354,6 +5370,7 @@
             "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
             "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "hoist-non-react-statics": "^3.3.0"
             },
@@ -5476,7 +5493,6 @@
             "integrity": "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -5491,7 +5507,8 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
             "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/pbf": {
             "version": "3.0.5",
@@ -5503,14 +5520,14 @@
             "version": "15.7.15",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
             "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/react": {
             "version": "19.2.13",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
             "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -5530,6 +5547,7 @@
             "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
             "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "*"
             }
@@ -5580,7 +5598,6 @@
             "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
                 "@typescript-eslint/scope-manager": "8.54.0",
@@ -5620,7 +5637,6 @@
             "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.54.0",
                 "@typescript-eslint/types": "8.54.0",
@@ -6076,7 +6092,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -6555,6 +6570,7 @@
             "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
             "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
                 "cosmiconfig": "^7.0.0",
@@ -6729,7 +6745,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -7058,6 +7073,7 @@
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
             "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -7170,6 +7186,7 @@
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
             "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.2.1",
@@ -7186,6 +7203,7 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -7595,6 +7613,7 @@
             "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
             "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.8.7",
                 "csstype": "^3.0.2"
@@ -8067,7 +8086,6 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -8128,7 +8146,6 @@
             "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -8648,7 +8665,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
             "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/find-up": {
             "version": "4.1.0",
@@ -9243,6 +9261,7 @@
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
             "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "react-is": "^16.7.0"
             }
@@ -9251,7 +9270,8 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/hosted-git-info": {
             "version": "2.8.9",
@@ -9474,6 +9494,7 @@
             "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
             "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@formatjs/ecma402-abstract": "2.3.6",
                 "@formatjs/fast-memoize": "2.2.7",
@@ -10055,7 +10076,6 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -11165,7 +11185,6 @@
             "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.18.1.tgz",
             "integrity": "sha512-Izc8dee2zkmb6Pn9hXFbVioPRLXJz1OFUcrvri69MhFACPU4bhLyVmhEsD9AyW1qOAP0Yvhzm60v63xdMIHPPw==",
             "license": "SEE LICENSE IN LICENSE.txt",
-            "peer": true,
             "workspaces": [
                 "src/style-spec",
                 "test/build/vite",
@@ -11288,7 +11307,6 @@
             "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "marked": "bin/marked.js"
             },
@@ -12260,7 +12278,6 @@
             "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -12492,7 +12509,8 @@
             "version": "19.2.4",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
             "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-map-gl": {
             "version": "8.1.0",
@@ -12533,6 +12551,7 @@
             "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
             "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.5.5",
                 "dom-helpers": "^5.0.1",
@@ -12974,7 +12993,8 @@
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
             "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/semver": {
             "version": "7.7.4",
@@ -13243,6 +13263,7 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13625,7 +13646,8 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
             "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/supercluster": {
             "version": "8.0.1",
@@ -13843,7 +13865,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -14005,7 +14026,6 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -14187,7 +14207,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -14481,7 +14500,6 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -14552,9 +14570,9 @@
             }
         },
         "node_modules/vite-plugin-checker": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.9.3.tgz",
-            "integrity": "sha512-Tf7QBjeBtG7q11zG0lvoF38/2AVUzzhMNu+Wk+mcsJ00Rk/FpJ4rmUviVJpzWkagbU13cGXvKpt7CMiqtxVTbQ==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.12.0.tgz",
+            "integrity": "sha512-CmdZdDOGss7kdQwv73UyVgLPv0FVYe5czAgnmRX2oKljgEvSrODGuClaV3PDR2+3ou7N/OKGauDDBjy2MB07Rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14562,26 +14580,26 @@
                 "chokidar": "^4.0.3",
                 "npm-run-path": "^6.0.0",
                 "picocolors": "^1.1.1",
-                "picomatch": "^4.0.2",
-                "strip-ansi": "^7.1.0",
+                "picomatch": "^4.0.3",
                 "tiny-invariant": "^1.3.3",
-                "tinyglobby": "^0.2.13",
+                "tinyglobby": "^0.2.15",
                 "vscode-uri": "^3.1.0"
             },
             "engines": {
-                "node": ">=14.16"
+                "node": ">=16.11"
             },
             "peerDependencies": {
                 "@biomejs/biome": ">=1.7",
-                "eslint": ">=7",
+                "eslint": ">=9.39.1",
                 "meow": "^13.2.0",
                 "optionator": "^0.9.4",
+                "oxlint": ">=1",
                 "stylelint": ">=16",
                 "typescript": "*",
-                "vite": ">=2.0.0",
+                "vite": ">=5.4.21",
                 "vls": "*",
                 "vti": "*",
-                "vue-tsc": "~2.2.10"
+                "vue-tsc": "~2.2.10 || ^3.0.0"
             },
             "peerDependenciesMeta": {
                 "@biomejs/biome": {
@@ -14594,6 +14612,9 @@
                     "optional": true
                 },
                 "optionator": {
+                    "optional": true
+                },
+                "oxlint": {
                     "optional": true
                 },
                 "stylelint": {
@@ -14654,22 +14675,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/vite-plugin-checker/node_modules/strip-ansi": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/vite-plugin-dts": {
@@ -14738,7 +14743,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -15169,6 +15173,127 @@
                 "@luma.gl/engine": "~9.0.0"
             }
         },
+        "packages/network-map-layers/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/network-map-layers/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/network-map-layers/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "packages/network-map-layers/node_modules/strip-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "packages/network-map-layers/node_modules/vite-plugin-checker": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.9.3.tgz",
+            "integrity": "sha512-Tf7QBjeBtG7q11zG0lvoF38/2AVUzzhMNu+Wk+mcsJ00Rk/FpJ4rmUviVJpzWkagbU13cGXvKpt7CMiqtxVTbQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "chokidar": "^4.0.3",
+                "npm-run-path": "^6.0.0",
+                "picocolors": "^1.1.1",
+                "picomatch": "^4.0.2",
+                "strip-ansi": "^7.1.0",
+                "tiny-invariant": "^1.3.3",
+                "tinyglobby": "^0.2.13",
+                "vscode-uri": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "peerDependencies": {
+                "@biomejs/biome": ">=1.7",
+                "eslint": ">=7",
+                "meow": "^13.2.0",
+                "optionator": "^0.9.4",
+                "stylelint": ">=16",
+                "typescript": "*",
+                "vite": ">=2.0.0",
+                "vls": "*",
+                "vti": "*",
+                "vue-tsc": "~2.2.10"
+            },
+            "peerDependenciesMeta": {
+                "@biomejs/biome": {
+                    "optional": true
+                },
+                "eslint": {
+                    "optional": true
+                },
+                "meow": {
+                    "optional": true
+                },
+                "optionator": {
+                    "optional": true
+                },
+                "stylelint": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                },
+                "vls": {
+                    "optional": true
+                },
+                "vti": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                }
+            }
+        },
         "packages/network-viewer-core": {
             "name": "@powsybl/network-viewer-core",
             "version": "3.3.0-dev.0",
@@ -15190,6 +15315,127 @@
             "engines": {
                 "node": ">=22",
                 "npm": "^10.9.2"
+            }
+        },
+        "packages/network-viewer-core/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/network-viewer-core/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "packages/network-viewer-core/node_modules/picomatch": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "packages/network-viewer-core/node_modules/strip-ansi": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "packages/network-viewer-core/node_modules/vite-plugin-checker": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-checker/-/vite-plugin-checker-0.9.3.tgz",
+            "integrity": "sha512-Tf7QBjeBtG7q11zG0lvoF38/2AVUzzhMNu+Wk+mcsJ00Rk/FpJ4rmUviVJpzWkagbU13cGXvKpt7CMiqtxVTbQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.27.1",
+                "chokidar": "^4.0.3",
+                "npm-run-path": "^6.0.0",
+                "picocolors": "^1.1.1",
+                "picomatch": "^4.0.2",
+                "strip-ansi": "^7.1.0",
+                "tiny-invariant": "^1.3.3",
+                "tinyglobby": "^0.2.13",
+                "vscode-uri": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "peerDependencies": {
+                "@biomejs/biome": ">=1.7",
+                "eslint": ">=7",
+                "meow": "^13.2.0",
+                "optionator": "^0.9.4",
+                "stylelint": ">=16",
+                "typescript": "*",
+                "vite": ">=2.0.0",
+                "vls": "*",
+                "vti": "*",
+                "vue-tsc": "~2.2.10"
+            },
+            "peerDependenciesMeta": {
+                "@biomejs/biome": {
+                    "optional": true
+                },
+                "eslint": {
+                    "optional": true
+                },
+                "meow": {
+                    "optional": true
+                },
+                "optionator": {
+                    "optional": true
+                },
+                "stylelint": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                },
+                "vls": {
+                    "optional": true
+                },
+                "vti": {
+                    "optional": true
+                },
+                "vue-tsc": {
+                    "optional": true
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
         "publish:all": "npm publish --workspaces --include-workspace-root"
     },
     "workspaces": [
-        "packages/network-map-layers",
-        "packages/network-viewer-core"
+        "packages/*"
     ],
     "overrides": {
         "@deck.gl/mapbox": {
@@ -124,7 +123,7 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.31.0",
         "vite": "^6.2.2",
-        "vite-plugin-checker": "^0.9.1",
+        "vite-plugin-checker": "^0.12.0",
         "vite-plugin-dts": "^4.5.3",
         "vite-plugin-svgr": "^4.3.0"
     }

--- a/packages/network-map-layers/tsconfig.json
+++ b/packages/network-map-layers/tsconfig.json
@@ -1,18 +1,7 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "module": "esnext",
-        "moduleResolution": "node",
-        "target": "es6",
-        "declaration": true,
-        "outDir": "./dist",
-        "strict": true,
-        "skipLibCheck": true,
-        "esModuleInterop": true,
-        "forceConsistentCasingInFileNames": true,
-        "allowSyntheticDefaultImports": true,
-        "noFallthroughCasesInSwitch": true,
-        "resolveJsonModule": true,
-        "noEmit": true
+        "outDir": "./dist"
     },
     "include": ["src"]
 }

--- a/packages/network-viewer-core/tsconfig.json
+++ b/packages/network-viewer-core/tsconfig.json
@@ -1,18 +1,7 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "module": "esnext",
-        "moduleResolution": "node",
-        "target": "es6",
-        "declaration": true,
-        "outDir": "./dist",
-        "strict": true,
-        "skipLibCheck": true,
-        "esModuleInterop": true,
-        "forceConsistentCasingInFileNames": true,
-        "allowSyntheticDefaultImports": true,
-        "noFallthroughCasesInSwitch": true,
-        "resolveJsonModule": true,
-        "noEmit": true
+        "outDir": "./dist"
     },
     "include": ["src"]
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -26,11 +26,6 @@ const config = {
             options: { parser: 'dot-properties' },
         },
         {
-            // .frag files are recognized as JavaScript files by default
-            files: ['*.frag'],
-            options: { parser: 'glsl-parser' },
-        },
-        {
             files: ['.github/**/*'],
             options: { tabWidth: 2 },
         },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "esnext",
+        "moduleResolution": "node",
+        "target": "es6",
+        "declaration": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "allowSyntheticDefaultImports": true,
+        "noFallthroughCasesInSwitch": true,
+        "resolveJsonModule": true,
+        "noEmit": true
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,19 @@
 {
+    "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "module": "esnext",
-        "moduleResolution": "bundler",
-        "target": "es6",
-        "declaration": true,
+        "baseUrl": ".",
+        "paths": {
+            "@powsybl/network-viewer-core": ["packages/network-viewer-core/src/"],
+            "@powsybl/network-map-layers": ["packages/network-map-layers/src/"],
+            "vite-plugin-checker": ["node_modules/vite-plugin-checker/dist/main.d.ts"]
+        },
         "outDir": "./dist",
-        "strict": true,
-        "skipLibCheck": true,
-        "esModuleInterop": true,
-        "forceConsistentCasingInFileNames": true,
-        "allowSyntheticDefaultImports": true,
-        "noFallthroughCasesInSwitch": true,
-        "resolveJsonModule": true,
-        "noEmit": true,
         "jsx": "react-jsx"
     },
     "include": [
         "src",
         "demo", // we can let demo because the file generation is managed by vite and we have noEmit anyway
+        "utils",
         "setupTests.ts",
         "svgTransform.ts",
         // We must list config files in typescript because needed by prettier when called by eslint as plugin

--- a/utils/viteEslintChecker.ts
+++ b/utils/viteEslintChecker.ts
@@ -16,11 +16,7 @@ export const eslintCmdWithOptions = () => {
         : `${eslintCmd} --ignore-pattern "**/*.{test,spec}.*" "**/src/**/*.{js,jsx,ts,tsx}"`;
 };
 
-export const viteEslintChecker = (
-    isPreview: boolean | undefined,
-    command: 'build' | 'serve',
-    tsconfigPath?: string
-) => {
+export const viteEslintChecker = (isPreview: boolean | undefined, command: 'build' | 'serve') => {
     return (
         !isPreview &&
         checker({
@@ -28,11 +24,6 @@ export const viteEslintChecker = (
                 initialIsOpen: true,
                 position: 'bl',
             },
-            typescript: tsconfigPath
-                ? {
-                      tsconfigPath,
-                  }
-                : true,
             eslint: {
                 lintCommand: command === 'build' ? `${eslintCmd} .` : eslintCmdWithOptions(),
                 useFlatConfig: true,


### PR DESCRIPTION
remove prettier glsl remains

to validate do :
git clean -dfx
npm ci
npx tsc -p packages/network-map-layers/tsconfig.json --noEmit 
npx tsc -p packages/network-viewer-core/tsconfig.json --noEmit
npx tsc -p demo/tsconfig.json --noEmit
npm run check
npm run lint
npm run lint:format
npm start

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix the tsconfig to have no typescript error after checkout without build


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently when doing a checkout, npm i and npm run check it fails


**What is the new behavior (if this is a feature change)?**
ts check valid on checkout

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
