### PR TITLE
Update github-ci actions to latest commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   run-release:
-    uses: powsybl/github-ci/.github/workflows/release-frontend-lib-generic.yml@5e13dcb03778dc9a47bd0adbd84c48392b32cd46
+    uses: powsybl/github-ci/.github/workflows/release-frontend-lib-generic.yml@3ed0caeb3395e55868884f466d726ddaee877850
     with:
       versionType: ${{ github.event.inputs.versionType }}
       nodeAuthToken: ${{ github.event.inputs.nodeAuthToken }}


### PR DESCRIPTION
This PR updates GitHub Actions workflows to reference the latest commit of powsybl/github-ci.