### PR TITLE
[nad-viewer] Add branch middle infos when creating SVG from diagram metadata

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -55,6 +55,9 @@
                 <div id="svg-container-nad-partial-network"></div>
                 <div id="svg-container-nad-partial-network-c"></div>
                 <div class="break"></div>
+                <div id="svg-container-nad-multibus-vlnodes-middle-arrow"></div>
+                <div id="svg-container-nad-multibus-vlnodes-middle-arrow-c"></div>
+                <div class="break"></div>
                 <div id="svg-container-nad-pst-hvdc-multiple-labels"></div>
                 <div id="svg-container-nad-pst-hvdc-multiple-labels-c"></div>
                 <div class="break"></div>
@@ -65,8 +68,6 @@
                 <div id="svg-container-nad-pegase-network-adaptive-zoom"></div>
                 <div class="break"></div>
                 <div id="svg-container-nad-partial-network-adaptive-zoom"></div>
-                <div id="svg-container-nad-multibus-vlnodes-middle-arrow"></div>
-                <div class="break"></div>
                 <div id="svg-container-nad-multibus-vlnodes-limit-percentage"></div>
                 <div class="break"></div>
                 <div id="svg-container-nad-hoverCallback"></div>

--- a/demo/src/diagram-viewers/add-diagrams.ts
+++ b/demo/src/diagram-viewers/add-diagrams.ts
@@ -455,7 +455,7 @@ export const addNadToDemo = () => {
                 onBendLineCallback: handleLineBending,
 
                 enableAdaptiveTextZoom: true,
-                adaptiveTextZoomThreshold: 850,
+                adaptiveTextZoomThreshold: 1800,
             };
             new NetworkAreaDiagramViewer(
                 document.getElementById('svg-container-nad-multibus-vlnodes-middle-arrow')!,
@@ -464,6 +464,13 @@ export const addNadToDemo = () => {
                 nadViewerParametersOptions
             );
         });
+
+    new NetworkAreaDiagramViewer(
+        document.getElementById('svg-container-nad-multibus-vlnodes-middle-arrow-c')!,
+        '',
+        NadSvgMultibusVLNodesMiddleArrowExampleMeta,
+        nadViewerParametersOptions
+    );
 
     fetch(NadSvgMultibusVLNodesLimitPercentageExample)
         .then((response) => response.text())

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/edge-router.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/edge-router.ts
@@ -18,8 +18,10 @@ export class EdgeRouter {
     diagramMetadata: DiagramMetadata;
     svgParameters: SvgParameters;
     edgePoints: Record<string, [Point[], Point[]]> = {};
-    edgeSideArrowData: Record<string, [[Point, number], [Point, number]]> = {};
+    edgeSideData: Record<string, [[Point, number], [Point, number]]> = {};
     edgeSideLabelData: Record<string, [LabelData, LabelData]> = {};
+    edgeMiddleData: Record<string, [Point, number]> = {};
+    edgeMiddleLabelData: Record<string, LabelData> = {};
     threeWtEdgePoints: Record<string, [Point, Point]> = {};
     nodeAngles: Record<string, number[]> = {};
 
@@ -46,28 +48,48 @@ export class EdgeRouter {
         return side == '1' ? edgesPoints[0] : edgesPoints[1];
     }
 
-    public getEdgeSideArrowCenter(edgeId: string, side: string): Point | undefined {
-        const edgeSideArrowData = this.edgeSideArrowData[edgeId];
-        if (!edgeSideArrowData) {
+    public getEdgeSideinfoPoint(edgeId: string, side: string): Point | undefined {
+        const edgeSideData = this.edgeSideData[edgeId];
+        if (!edgeSideData) {
             return undefined;
         }
-        return side == '1' ? edgeSideArrowData[0][0] : edgeSideArrowData[1][0];
+        return side == '1' ? edgeSideData[0][0] : edgeSideData[1][0];
     }
 
-    public getEdgeSideArrowAngle(edgeId: string, side: string): number | undefined {
-        const edgeSideArrowData = this.edgeSideArrowData[edgeId];
-        if (!edgeSideArrowData) {
+    public getEdgeSideInfoAngle(edgeId: string, side: string): number | undefined {
+        const edgeSideData = this.edgeSideData[edgeId];
+        if (!edgeSideData) {
             return undefined;
         }
-        return side == '1' ? edgeSideArrowData[0][1] : edgeSideArrowData[1][1];
+        return side == '1' ? edgeSideData[0][1] : edgeSideData[1][1];
     }
 
     public getEdgeSideLabelData(edgeId: string, side: string): LabelData | undefined {
-        const edgeArrowLabelData = this.edgeSideLabelData[edgeId];
-        if (!edgeArrowLabelData) {
+        const edgeSideLabelData = this.edgeSideLabelData[edgeId];
+        if (!edgeSideLabelData) {
             return undefined;
         }
-        return side == '1' ? edgeArrowLabelData[0] : edgeArrowLabelData[1];
+        return side == '1' ? edgeSideLabelData[0] : edgeSideLabelData[1];
+    }
+
+    public getEdgeMiddleInfoPoint(edgeId: string): Point | undefined {
+        const edgeMiddleData = this.edgeMiddleData[edgeId];
+        if (!edgeMiddleData) {
+            return undefined;
+        }
+        return edgeMiddleData[0];
+    }
+
+    public getEdgeMiddleInfoAngle(edgeId: string): number | undefined {
+        const edgeMiddleData = this.edgeMiddleData[edgeId];
+        if (!edgeMiddleData) {
+            return undefined;
+        }
+        return edgeMiddleData[1];
+    }
+
+    public getEdgeMiddleLabelData(edgeId: string): LabelData | undefined {
+        return this.edgeMiddleLabelData[edgeId];
     }
 
     public getThreeWtEdgePoints(edgeId: string): Point[] | undefined {
@@ -154,16 +176,23 @@ export class EdgeRouter {
         const node2Angles: number[] = this.nodeAngles[edge.node2] ?? [];
         node2Angles.push(angle2);
         this.nodeAngles[edge.node2] = node2Angles;
+        this.storeEdgeInfos(edge, halfEdges);
+    }
+
+    private storeEdgeInfos(edge: EdgeMetadata, halfEdges: HalfEdge[] | null[]) {
         if (edge.edgeInfo1 || edge.edgeInfo2) {
-            this.storeEdgeSideInfos(edge.svgId, halfEdges);
+            this.storeEdgeSideData(edge.svgId, halfEdges);
+        }
+        if (edge.edgeInfoMiddle) {
+            this.storeEdgeMiddleData(edge.svgId, halfEdges);
         }
     }
 
-    private storeEdgeSideInfos(edgeId: string, halfEdges: HalfEdge[] | null[]) {
+    private storeEdgeSideData(edgeId: string, halfEdges: HalfEdge[] | null[]) {
         if (!halfEdges[0] || !halfEdges[1]) {
             return;
         }
-        this.edgeSideArrowData[edgeId] = [
+        this.edgeSideData[edgeId] = [
             [
                 HalfEdgeUtils.getArrowCenter(halfEdges[0], this.svgParameters),
                 HalfEdgeUtils.getArrowRotation(halfEdges[0]),
@@ -177,6 +206,34 @@ export class EdgeRouter {
             HalfEdgeUtils.getLabelData(halfEdges[0], this.svgParameters.getArrowLabelShift()),
             HalfEdgeUtils.getLabelData(halfEdges[1], this.svgParameters.getArrowLabelShift()),
         ];
+    }
+
+    private storeEdgeMiddleData(edgeId: string, halfEdges: HalfEdge[] | null[]) {
+        const infoPointAndAngle = HalfEdgeUtils.getInfoPointAndAngle(halfEdges[0], halfEdges[1]);
+        const edgesPoints = this.edgePoints[edgeId];
+        const halfEdgePoints = edgesPoints ? edgesPoints[0] : undefined;
+        if (infoPointAndAngle && halfEdgePoints) {
+            const angle = DiagramUtils.getAngle(halfEdgePoints.at(-2)!, halfEdgePoints.at(-1)!);
+            const rotationAngle = DiagramUtils.radToDeg(
+                angle + (angle > Math.PI / 2 ? (-3 * Math.PI) / 2 : Math.PI / 2)
+            );
+            this.edgeMiddleData[edgeId] = [infoPointAndAngle[0], rotationAngle];
+            const internalShiftAndStyle = DiagramUtils.getLabelShiftAndStyle(
+                angle,
+                false,
+                this.svgParameters.getArrowLabelShift()
+            );
+            const externalShiftAndStyle = DiagramUtils.getLabelShiftAndStyle(
+                angle,
+                true,
+                this.svgParameters.getArrowLabelShift()
+            );
+            this.edgeMiddleLabelData[edgeId] = {
+                angle: infoPointAndAngle[1],
+                internal: { shift: internalShiftAndStyle[0], style: internalShiftAndStyle[1] },
+                external: { shift: externalShiftAndStyle[0], style: externalShiftAndStyle[1] },
+            };
+        }
     }
 
     private storeLoopEdges(edges: Record<string, EdgeMetadata[]>) {
@@ -309,9 +366,7 @@ export class EdgeRouter {
             return;
         }
         this.edgePoints[edge.svgId] = [halfEdges[0].edgePoints, halfEdges[1].edgePoints];
-        if (edge.edgeInfo1 || edge.edgeInfo2) {
-            this.storeEdgeSideInfos(edge.svgId, halfEdges);
-        }
+        this.storeEdgeInfos(edge, halfEdges);
     }
 
     private storeThreeWtEdges(edgesMap: Record<string, EdgeMetadata[]>) {

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
@@ -53,9 +53,7 @@ export class SvgWriter {
         // add edges and infos
         const edgesAndInfos = this.getEdgesAndInfos();
         svg.appendChild(edgesAndInfos.edges);
-        if (edgesAndInfos.edgeInfos.childElementCount > 0) {
-            svg.appendChild(edgesAndInfos.edgeInfos);
-        }
+        svg.appendChild(edgesAndInfos.edgeInfos);
         // add 3wt edges
         const threeWtEdges = MetadataUtils.getThreeWtEdges(this.diagramMetadata.edges);
         if (threeWtEdges && threeWtEdges.length > 0) {
@@ -176,10 +174,13 @@ export class SvgWriter {
             if (!MetadataUtils.isThreeWtEdge(edge)) {
                 gEdgesElement.appendChild(this.getEdge(edge));
                 if (edge.edgeInfo1 && !edge.invisible1) {
-                    gEdgeInfosElement.appendChild(this.getEdgeInfo(edge, '1', edge.edgeInfo1));
+                    gEdgeInfosElement.appendChild(this.getEdgeSideInfo(edge, '1', edge.edgeInfo1));
                 }
                 if (edge.edgeInfo2 && !edge.invisible2) {
-                    gEdgeInfosElement.appendChild(this.getEdgeInfo(edge, '2', edge.edgeInfo2));
+                    gEdgeInfosElement.appendChild(this.getEdgeSideInfo(edge, '2', edge.edgeInfo2));
+                }
+                if (edge.edgeInfoMiddle) {
+                    gEdgeInfosElement.appendChild(this.getEdgeMiddleInfo(edge, edge.edgeInfoMiddle));
                 }
             }
         });
@@ -312,11 +313,11 @@ export class SvgWriter {
         return polylineElement;
     }
 
-    private getEdgeInfo(edge: EdgeMetadata, side: string, info: EdgeInfoMetadata): SVGGElement {
+    private getEdgeSideInfo(edge: EdgeMetadata, side: string, info: EdgeInfoMetadata): SVGGElement {
         // create info element
         const gEdgeInfoElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         gEdgeInfoElement.id = info.svgId;
-        const arrowCenter = this.edgeRouter?.getEdgeSideArrowCenter(edge.svgId, side);
+        const arrowCenter = this.edgeRouter?.getEdgeSideinfoPoint(edge.svgId, side);
         if (arrowCenter) {
             gEdgeInfoElement.setAttribute(
                 'transform',
@@ -327,7 +328,7 @@ export class SvgWriter {
         if (info.direction) {
             gEdgeInfoElement.appendChild(
                 this.getEdgeInfoArrow(
-                    this.edgeRouter?.getEdgeSideArrowAngle(edge.svgId, side),
+                    this.edgeRouter?.getEdgeSideInfoAngle(edge.svgId, side),
                     info.direction,
                     info.infoTypeB
                 )
@@ -408,6 +409,51 @@ export class SvgWriter {
             edgeInfoLabelElement.classList.add(edgeInfoClass);
         }
         return edgeInfoLabelElement;
+    }
+
+    private getEdgeMiddleInfo(edge: EdgeMetadata, info: EdgeInfoMetadata): SVGGElement {
+        const gEdgeMiddleInfoElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        gEdgeMiddleInfoElement.id = info.svgId;
+        const middleInfoPoint = this.edgeRouter?.getEdgeMiddleInfoPoint(edge.svgId);
+        if (middleInfoPoint) {
+            gEdgeMiddleInfoElement.setAttribute(
+                'transform',
+                'translate(' + DiagramUtils.getFormattedPoint(middleInfoPoint) + ')'
+            );
+        }
+        // add arrow element
+        if (info.direction) {
+            gEdgeMiddleInfoElement.appendChild(
+                this.getEdgeInfoArrow(
+                    this.edgeRouter?.getEdgeMiddleInfoAngle(edge.svgId),
+                    info.direction,
+                    info.infoTypeB
+                )
+            );
+        }
+        let x = 0;
+        let style: string | undefined = 'text-anchor:middle';
+        const labelData = this.edgeRouter?.getEdgeMiddleLabelData(edge.svgId);
+        if (labelData === undefined) return gEdgeMiddleInfoElement;
+        // add labelB element
+        if (info.labelB && info.labelA) {
+            gEdgeMiddleInfoElement.appendChild(
+                this.getEdgeInfoLabel(
+                    labelData.angle,
+                    labelData.external.shift,
+                    labelData.external.style,
+                    info.labelB,
+                    info.infoTypeB
+                )
+            );
+            x = labelData.internal.shift;
+            style = labelData.internal.style;
+        }
+        // add labelA element
+        gEdgeMiddleInfoElement.appendChild(
+            this.getEdgeInfoLabel(labelData.angle, x, style, info.labelA, info.infoTypeA)
+        );
+        return gEdgeMiddleInfoElement;
     }
 
     private getTextNodesAndEdges(): { textNodes: SVGForeignObjectElement; textEdges: SVGGElement } {


### PR DESCRIPTION


**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
feature



**What is the current behavior?**
When creating the SVG from diagram metadata, the SvgWriter does not create branch middle infos



**What is the new behavior (if this is a feature change)?**
When creating the SVG from diagram metadata, the SvgWriter creates branch side infos


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

