### PR TITLE
[nad-viewer] Fix Edge Infos mis positioned when using `adaptiveTextZoom` and `moveTextNodeToCoordinates` or `moveNodeToCoordinates`

### DIFF
--- a/demo/src/diagram-viewers/add-diagrams.ts
+++ b/demo/src/diagram-viewers/add-diagrams.ts
@@ -451,14 +451,16 @@ export const addNadToDemo = () => {
                 onBendLineCallback: handleLineBending,
 
                 enableAdaptiveTextZoom: true,
-                adaptiveTextZoomThreshold: 850,
+                adaptiveTextZoomThreshold: 3000,
             };
-            new NetworkAreaDiagramViewer(
+            const nadViewer = new NetworkAreaDiagramViewer(
                 document.getElementById('svg-container-nad-multibus-vlnodes-limit-percentage')!,
                 svgContent,
                 NadSvgMultibusVLNodesLimitPercentageExampleMeta,
                 nadViewerParametersOptions
             );
+
+            nadViewer.moveNodeToCoordinates('VL5', -100, -50);
         });
 
     fetch(NadSvgMultibusVLNodes14Example)

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -263,6 +263,8 @@ export class NetworkAreaDiagramViewer {
                 this.updateNodeMetadata(elemToMove, new Point(x, y));
                 // update and redraw element
                 this.updateElement(elemToMove);
+                // reset initial position now that node is moved
+                // to avoid wrong offset if the node is moved again before mouse up
                 this.initialPosition = null;
             }
         }
@@ -307,6 +309,8 @@ export class NetworkAreaDiagramViewer {
 
         //update and redraw element
         this.updateElement(elemToMove);
+        // reset initial position now that text node is moved
+        // to avoid wrong offset if the text node is moved again before mouse up
         this.initialPosition = null;
     }
 
@@ -1900,7 +1904,10 @@ export class NetworkAreaDiagramViewer {
                     nbGroupedEdges = groupedEdges.length;
                 }
             }
-            halfEdges = this.getHalfEdges(edge, iEdge, nbGroupedEdges);
+            // We don't need to consider this.initialPosition and this.draggedElement here,
+            // during the adaptiveTextZoom update, edges are not moved by dragging.
+            // getHalfEdgesForEdgeInfos is only used for edge infos position update.
+            halfEdges = this.getHalfEdges(edge, iEdge, nbGroupedEdges, undefined, undefined, null);
         }
         return halfEdges;
     }
@@ -1998,8 +2005,6 @@ export class NetworkAreaDiagramViewer {
     }
 
     private adaptiveZoomViewboxUpdate(maxDisplayedSize: number) {
-        // ensure no leftover drag translation affects adaptive updates
-        // this.initialPosition = null;
         if (maxDisplayedSize > this.nadViewerParameters.getThresholdAdaptiveTextZoom()) {
             this.edgeInfosSection?.replaceChildren();
             this.textEdgesSection?.replaceChildren();
@@ -2811,7 +2816,14 @@ export class NetworkAreaDiagramViewer {
         }
     }
 
-    private getHalfEdges(edge: EdgeMetadata, iEdge: number, groupedEdgesCount: number, point1?: Point, point2?: Point) {
+    private getHalfEdges(
+        edge: EdgeMetadata,
+        iEdge: number,
+        groupedEdgesCount: number,
+        point1?: Point,
+        point2?: Point,
+        initialPosition: Point | null = this.initialPosition
+    ) {
         // Detect if the edge is linked to an invisible node (not in DOM)
         const invisibleSide = MetadataUtils.getInvisibleSide(edge);
 
@@ -2824,7 +2836,7 @@ export class NetworkAreaDiagramViewer {
                 visibleSide,
                 groupedEdgesCount > 1,
                 this.diagramMetadata,
-                this.initialPosition,
+                initialPosition,
                 this.svgParameters
             );
         } else {

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -263,6 +263,7 @@ export class NetworkAreaDiagramViewer {
                 this.updateNodeMetadata(elemToMove, new Point(x, y));
                 // update and redraw element
                 this.updateElement(elemToMove);
+                this.initialPosition = null;
             }
         }
     }
@@ -306,6 +307,7 @@ export class NetworkAreaDiagramViewer {
 
         //update and redraw element
         this.updateElement(elemToMove);
+        this.initialPosition = null;
     }
 
     private hasNodeInteraction(): boolean {
@@ -1996,6 +1998,8 @@ export class NetworkAreaDiagramViewer {
     }
 
     private adaptiveZoomViewboxUpdate(maxDisplayedSize: number) {
+        // ensure no leftover drag translation affects adaptive updates
+        // this.initialPosition = null;
         if (maxDisplayedSize > this.nadViewerParameters.getThresholdAdaptiveTextZoom()) {
             this.edgeInfosSection?.replaceChildren();
             this.textEdgesSection?.replaceChildren();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When using nad-viewer and public functions `moveTextNodeToCoordinates` or `moveNodeToCoordinates` in the client side, with de `adaptiveTextZoom` mode, and a NAD containing half edges, sometimes the half edge Infos are completely mis positioned.


**What is the new behavior (if this is a feature change)?**
fix(NetworkAreaDiagramViewer): reset `initialPosition` at the end of public functions `moveTextNodeToCoordinates` and `moveNodeToCoordinates` to avoid future mis computation with `getTranslatedPolyline` in the `enableAdaptiveTextZoom` mode and halfEdges.
Suggestion : should we reset `initialPosition` at the beginning of `adaptiveZoomViewboxUpdate` to avoid other scenario of this kind ? @CBiasuzzi ?

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No