### PR TITLE
[nad-viewer] Draw both side labels when using adaptive zoom

### DIFF
--- a/demo/src/diagram-viewers/add-diagrams.ts
+++ b/demo/src/diagram-viewers/add-diagrams.ts
@@ -264,6 +264,8 @@ export const addNadToDemo = () => {
                 onToggleHoverCallback: handleToggleNadHover,
                 onRightClickCallback: handleRightClick,
                 onBendLineCallback: handleLineBending,
+                enableAdaptiveTextZoom: true,
+                adaptiveTextZoomThreshold: 1500,
             };
             new NetworkAreaDiagramViewer(
                 document.getElementById('svg-container-nad-pst-hvdc-multiple-labels')!,

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -2221,16 +2221,8 @@ export class NetworkAreaDiagramViewer {
             edgeInfo.classList.add(edgeInfoClass);
         }
 
-        if (typeof value === 'number') {
-            const arrowPath = DiagramUtils.getArrowPath(edgeInfoMetadata.direction, this.svgParameters);
-            if (arrowPath) {
-                const edgeInfoArrow = this.getOrCreateEdgeInfoArrow(edgeInfo);
-                edgeInfoArrow.setAttribute('d', arrowPath);
-                const edgeInfoClass = DiagramUtils.getArrowClass(edgeInfoMetadata.direction);
-                if (edgeInfoClass) {
-                    edgeInfoArrow.classList.add(edgeInfoClass);
-                }
-            }
+        if (edgeInfoMetadata.direction) {
+            this.addBranchSideArrowElement(edgeInfo, edgeInfoMetadata.direction);
         }
 
         const branchLabelBElement = this.getOrCreateEdgeInfoText(edgeInfo, 1);
@@ -2242,6 +2234,18 @@ export class NetworkAreaDiagramViewer {
         }
 
         this.redrawEdgeArrowAndLabels(halfEdge, edgeInfo);
+    }
+
+    private addBranchSideArrowElement(edgeInfo: SVGElement, direction: string | undefined) {
+        const arrowPath = DiagramUtils.getArrowPath(direction, this.svgParameters);
+        if (arrowPath) {
+            const edgeInfoArrow = this.getOrCreateEdgeInfoArrow(edgeInfo);
+            edgeInfoArrow.setAttribute('d', arrowPath);
+            const edgeInfoClass = DiagramUtils.getArrowClass(direction);
+            if (edgeInfoClass) {
+                edgeInfoArrow.classList.add(edgeInfoClass);
+            }
+        }
     }
 
     private setBranchMiddleLabel(

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -2233,8 +2233,13 @@ export class NetworkAreaDiagramViewer {
             }
         }
 
-        const branchLabelElement = this.getOrCreateEdgeInfoText(edgeInfo);
-        branchLabelElement.innerHTML = edgeInfoMetadata.labelB;
+        const branchLabelBElement = this.getOrCreateEdgeInfoText(edgeInfo, 1);
+        branchLabelBElement.innerHTML = edgeInfoMetadata.labelB;
+
+        if (edgeInfoMetadata.labelA) {
+            const branchLabelAElement = this.getOrCreateEdgeInfoText(edgeInfo, 2);
+            branchLabelAElement.innerHTML = edgeInfoMetadata.labelA;
+        }
 
         this.redrawEdgeArrowAndLabels(halfEdge, edgeInfo);
     }
@@ -2307,7 +2312,7 @@ export class NetworkAreaDiagramViewer {
         type: string | undefined,
         label: string | undefined
     ) {
-        const branchLabelElement = this.getOrCreateEdgeMiddleInfoText(edgeInfo, i);
+        const branchLabelElement = this.getOrCreateEdgeInfoText(edgeInfo, i);
         branchLabelElement.classList.remove('nad-active', 'nad-reactive', 'nad-current', 'nad-name');
         const edgeInfoClass = DiagramUtils.getEdgeInfoClass(type);
         if (edgeInfoClass) {
@@ -2339,16 +2344,7 @@ export class NetworkAreaDiagramViewer {
         return edgeInfoArrow;
     }
 
-    private getOrCreateEdgeInfoText(edgeInfo: SVGElement): SVGTextElement {
-        let edgeInfoText = edgeInfo.querySelector('text');
-        if (!edgeInfoText) {
-            edgeInfoText = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-            edgeInfo.appendChild(edgeInfoText);
-        }
-        return edgeInfoText;
-    }
-
-    private getOrCreateEdgeMiddleInfoText(edgeInfo: SVGElement, i: number): SVGTextElement {
+    private getOrCreateEdgeInfoText(edgeInfo: SVGElement, i: number): SVGTextElement {
         let edgeInfoText = edgeInfo.querySelector('text:nth-of-type(' + i + ')') as SVGTextElement;
         if (!edgeInfoText) {
             edgeInfoText = document.createElementNS('http://www.w3.org/2000/svg', 'text');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
In the NAD viewer, when using the adaptive zoom, for a node connected to an edge with both side labels (internal and external), only one label is drawn



**What is the new behavior (if this is a feature change)?**
In the NAD viewer, when using the adaptive zoom, for a node connected to an edge with both side labels (internal and external), both labels are drawn


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No