### PR TITLE
[nad-viewer] Fix setBranchStates functionality

### DIFF
--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -2216,13 +2216,17 @@ export class NetworkAreaDiagramViewer {
         if (!halfEdge) return;
 
         if (!edgeInfoMetadata) {
-            edgeInfoMetadata = this.getEdgeInfoMetadata(value);
+            edgeInfoMetadata = {
+                svgId: crypto.randomUUID(),
+                infoTypeB: 'ActivePower',
+            };
             if (side == '1') {
                 edge.edgeInfo1 = edgeInfoMetadata;
             } else {
                 edge.edgeInfo2 = edgeInfoMetadata;
             }
         }
+        this.updateEdgeInfoMetadata(edgeInfoMetadata, value);
 
         const edgeInfo = this.getOrCreateEdgeInfo(edgeInfoMetadata);
         if (!halfEdge.edgeInfoId) {
@@ -2263,17 +2267,17 @@ export class NetworkAreaDiagramViewer {
         this.redrawEdgeArrowAndLabels(halfEdge, edgeInfo);
     }
 
-    private getEdgeInfoMetadata(value: number | string): EdgeInfoMetadata {
-        const edgeInfoMetadata: EdgeInfoMetadata = {
-            svgId: crypto.randomUUID(),
-            infoTypeB: 'ActivePower',
-        };
+    private updateEdgeInfoMetadata(edgeInfoMetadata: EdgeInfoMetadata, value: number | string) {
         edgeInfoMetadata.labelB =
             typeof value === 'number'
                 ? value.toFixed(DiagramUtils.getEdgeInfoValuePrecision(edgeInfoMetadata.infoTypeB, this.svgParameters))
                 : value;
-        edgeInfoMetadata.direction = typeof value === 'number' ? DiagramUtils.getArrowDirection(value) : undefined;
-        return edgeInfoMetadata;
+        const direction = typeof value === 'number' ? DiagramUtils.getArrowDirection(value) : undefined;
+        if (edgeInfoMetadata.directionB) {
+            edgeInfoMetadata.directionB = direction;
+        } else {
+            edgeInfoMetadata.direction = direction;
+        }
     }
 
     private addBranchComponentElement(edgeInfo: SVGElement, componentType: string) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
The setBranchStates functionality of the NAD viewer allows to add a label, and the corresponding arrow, to a branch, but the update of the label, and corresponding arrow, does not work



**What is the new behavior (if this is a feature change)?**
The setBranchStates functionality allows to add and update a label, and the corresponding arrow


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No