### PR TITLE
[nad-viewer] Update creation of SVG from metada to diagram version 5.3

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -61,6 +61,9 @@
                 <div id="svg-container-nad-pst-hvdc-multiple-labels"></div>
                 <div id="svg-container-nad-pst-hvdc-multiple-labels-c"></div>
                 <div class="break"></div>
+                <div id="svg-container-nad-double-arrows"></div>
+                <div id="svg-container-nad-double-arrows-c"></div>
+                <div class="break"></div>
                 <div id="svg-container-nad-pegase-network"></div>
                 <div class="break"></div>
                 <div id="svg-container-nad-pegase-network-c"></div>
@@ -73,7 +76,6 @@
                 <div id="svg-container-nad-hoverCallback"></div>
                 <div id="svg-container-nad-pst-hvdc-custom"></div>
                 <div class="break"></div>
-                <div id="svg-container-nad-double-arrows"></div>
                 <div id="svg-container-nad-components"></div>
             </div>
             <div class="break"></div>

--- a/demo/src/diagram-viewers/add-diagrams.ts
+++ b/demo/src/diagram-viewers/add-diagrams.ts
@@ -661,6 +661,13 @@ export const addNadToDemo = () => {
             );
         });
 
+    new NetworkAreaDiagramViewer(
+        document.getElementById('svg-container-nad-double-arrows-c')!,
+        '',
+        NadSvgDoubleArrowsExampleMeta,
+        nadViewerParametersOptions
+    );
+
     fetch(NadSvgComponentsExample)
         .then((response) => response.text())
         .then((svgContent) => {

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-utils.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-utils.ts
@@ -11,6 +11,7 @@ import {
     getAngle,
     getFormattedPoint,
     getFormattedPolyline,
+    getFormattedValue,
     getPointAtDistance,
     getVoltageLevelCircleRadius,
 } from './diagram-utils';
@@ -430,17 +431,21 @@ export function createTextNode(
     textNode: TextNodeMetadata,
     node: NodeMetadata,
     busNodes: BusNodeMetadata[]
-): HTMLElement {
-    const newTextElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
-    newTextElement.style.position = 'absolute';
-    newTextElement.style.top = (node.y + textNode.shiftY).toFixed(0) + 'px';
-    newTextElement.style.left = (node.x + textNode.shiftX).toFixed(0) + 'px';
+): SVGForeignObjectElement {
+    const newTextElement = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject');
+    newTextElement.setAttribute('y', getFormattedValue(node.y + textNode.shiftY));
+    newTextElement.setAttribute('x', getFormattedValue(node.x + textNode.shiftX));
+    newTextElement.setAttribute('height', '1');
+    newTextElement.setAttribute('width', '1');
     newTextElement.id = textNode.svgId;
-    newTextElement.classList.add('nad-label-box');
+
+    const newDivElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+    newDivElement.classList.add('nad-label-box');
+    newTextElement.appendChild(newDivElement);
 
     const newVlNameElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
     newVlNameElement.textContent = textNode.equipmentId;
-    newTextElement.appendChild(newVlNameElement);
+    newDivElement.appendChild(newVlNameElement);
 
     for (const busNode of busNodes) {
         const newBusDivElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
@@ -452,7 +457,7 @@ export function createTextNode(
         newBusDivElement.appendChild(newBusLegendElement);
         newBusDivElement.appendChild(textNode);
 
-        newTextElement.appendChild(newBusDivElement);
+        newDivElement.appendChild(newBusDivElement);
     }
 
     return newTextElement;

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
@@ -317,31 +317,23 @@ export class SvgWriter {
         // create info element
         const gEdgeInfoElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         gEdgeInfoElement.id = info.svgId;
-        const arrowCenter = this.edgeRouter?.getEdgeSideinfoPoint(edge.svgId, side);
-        if (arrowCenter) {
-            gEdgeInfoElement.setAttribute(
-                'transform',
-                'translate(' + DiagramUtils.getFormattedPoint(arrowCenter) + ')'
-            );
+        const infoPoint = this.edgeRouter?.getEdgeSideinfoPoint(edge.svgId, side);
+        if (infoPoint) {
+            gEdgeInfoElement.setAttribute('transform', 'translate(' + DiagramUtils.getFormattedPoint(infoPoint) + ')');
         }
-        // add arrow element
-        if (info.direction) {
-            gEdgeInfoElement.appendChild(
-                this.getEdgeInfoArrow(
-                    this.edgeRouter?.getEdgeSideInfoAngle(edge.svgId, side),
-                    info.direction,
-                    info.infoTypeB
-                )
-            );
-        }
+        // add arrows
+        this.addEdgeInfoArrows(gEdgeInfoElement, info, this.edgeRouter?.getEdgeSideInfoAngle(edge.svgId, side));
+        // add labels
         const labelData = this.edgeRouter?.getEdgeSideLabelData(edge.svgId, side);
         if (labelData === undefined) return gEdgeInfoElement;
+        const factor: number =
+            info.directionA && info.directionB ? this.svgParameters.getDoubleArrowShiftFactorText() : 1;
         // add labelB element
         if (info.labelB) {
             gEdgeInfoElement.appendChild(
                 this.getEdgeInfoLabel(
                     labelData.angle,
-                    labelData.external.shift,
+                    labelData.external.shift * factor,
                     labelData.external.style,
                     info.labelB,
                     info.infoTypeB
@@ -353,7 +345,7 @@ export class SvgWriter {
             gEdgeInfoElement.appendChild(
                 this.getEdgeInfoLabel(
                     labelData.angle,
-                    labelData.internal.shift,
+                    labelData.internal.shift * factor,
                     labelData.internal.style,
                     info.labelA,
                     info.infoTypeA
@@ -363,17 +355,40 @@ export class SvgWriter {
         return gEdgeInfoElement;
     }
 
+    private addEdgeInfoArrows(
+        gEdgeInfoElement: SVGGElement,
+        info: EdgeInfoMetadata,
+        edgeSideInfoAngle: number | undefined
+    ) {
+        if (info.directionA && info.directionB) {
+            const arrowShift: number =
+                this.svgParameters.getArrowLabelShift() / this.svgParameters.getDoubleArrowShiftFactorArrows();
+            gEdgeInfoElement.appendChild(
+                this.getEdgeInfoArrow(edgeSideInfoAngle, info.directionB, info.infoTypeB, -arrowShift)
+            );
+            gEdgeInfoElement.appendChild(
+                this.getEdgeInfoArrow(edgeSideInfoAngle, info.directionA, info.infoTypeA, arrowShift)
+            );
+        } else if (info.direction) {
+            gEdgeInfoElement.appendChild(
+                this.getEdgeInfoArrow(edgeSideInfoAngle, info.direction, info.infoTypeB, undefined)
+            );
+        }
+    }
+
     private getEdgeInfoArrow(
         arrowAngle: number | undefined,
         direction: string,
-        type: string | undefined
+        type: string | undefined,
+        shift: number | undefined
     ): SVGPathElement {
         const edgeInfoArrowElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
         if (arrowAngle) {
-            edgeInfoArrowElement.setAttribute(
-                'transform',
-                'rotate(' + DiagramUtils.getFormattedValue(arrowAngle) + ')'
-            );
+            let arrowString: string = 'rotate(' + DiagramUtils.getFormattedValue(arrowAngle) + ')';
+            if (shift) {
+                arrowString += ' translate(' + DiagramUtils.getFormattedPoint(new Point(0, shift)) + ')';
+            }
+            edgeInfoArrowElement.setAttribute('transform', arrowString);
         }
         const arrowPath = DiagramUtils.getArrowPath(direction, this.svgParameters);
         if (arrowPath) {
@@ -421,32 +436,27 @@ export class SvgWriter {
                 'translate(' + DiagramUtils.getFormattedPoint(middleInfoPoint) + ')'
             );
         }
-        // add arrow element
-        if (info.direction) {
-            gEdgeMiddleInfoElement.appendChild(
-                this.getEdgeInfoArrow(
-                    this.edgeRouter?.getEdgeMiddleInfoAngle(edge.svgId),
-                    info.direction,
-                    info.infoTypeB
-                )
-            );
-        }
+        // add arrows
+        this.addEdgeInfoArrows(gEdgeMiddleInfoElement, info, this.edgeRouter?.getEdgeMiddleInfoAngle(edge.svgId));
+        // add labels
         let x = 0;
         let style: string | undefined = 'text-anchor:middle';
         const labelData = this.edgeRouter?.getEdgeMiddleLabelData(edge.svgId);
         if (labelData === undefined) return gEdgeMiddleInfoElement;
+        const factor: number =
+            info.directionA && info.directionB ? this.svgParameters.getDoubleArrowShiftFactorText() : 1;
         // add labelB element
         if (info.labelB && info.labelA) {
             gEdgeMiddleInfoElement.appendChild(
                 this.getEdgeInfoLabel(
                     labelData.angle,
-                    labelData.external.shift,
+                    labelData.external.shift * factor,
                     labelData.external.style,
                     info.labelB,
                     info.infoTypeB
                 )
             );
-            x = labelData.internal.shift;
+            x = labelData.internal.shift * factor;
             style = labelData.internal.style;
         }
         // add labelA element
@@ -456,26 +466,22 @@ export class SvgWriter {
         return gEdgeMiddleInfoElement;
     }
 
-    private getTextNodesAndEdges(): { textNodes: SVGForeignObjectElement; textEdges: SVGGElement } {
-        // create text nodes foreignObject element
-        const textNodesForeignObject = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject');
-        textNodesForeignObject.setAttribute('height', '1');
-        textNodesForeignObject.setAttribute('width', '1');
-        textNodesForeignObject.classList.add(SvgWriter.TEXT_NODES_CLASS);
-        const textNodesDiv = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
-        textNodesForeignObject.appendChild(textNodesDiv);
+    private getTextNodesAndEdges(): { textNodes: SVGGElement; textEdges: SVGGElement } {
+        // create text nodes g element
+        const textNodesGElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        textNodesGElement.classList.add(SvgWriter.TEXT_NODES_CLASS);
         // create text edges g element
-        const gTextEdgesElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-        gTextEdgesElement.classList.add(SvgWriter.TEXT_EDGES_CLASS);
+        const textEdgesGElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        textEdgesGElement.classList.add(SvgWriter.TEXT_EDGES_CLASS);
         // create text nodes and edges
         this.diagramMetadata.textNodes.forEach((textNode) => {
             const node = MetadataUtils.getNodeMetadata(textNode.vlNode, this.diagramMetadata);
             if (node && !node.invisible) {
                 const busNodes = MetadataUtils.getBusNodesMetadata(node.svgId, this.diagramMetadata.busNodes);
-                textNodesDiv.appendChild(SvgUtils.createTextNode(textNode, node, busNodes));
-                gTextEdgesElement.appendChild(SvgUtils.createTextEdge(textNode, node, busNodes, this.svgParameters));
+                textNodesGElement.appendChild(SvgUtils.createTextNode(textNode, node, busNodes));
+                textEdgesGElement.appendChild(SvgUtils.createTextEdge(textNode, node, busNodes, this.svgParameters));
             }
         });
-        return { textNodes: textNodesForeignObject, textEdges: gTextEdgesElement };
+        return { textNodes: textNodesGElement, textEdges: textEdgesGElement };
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
update



**What is the current behavior?**
The creation of SVG from metadata supports diagram 5.2, with a single foreign object for all the text boxes



**What is the new behavior (if this is a feature change)?**
The creation of SVG from metadata supports diagram 5.3, with a foreign object for each text box, and handling also double arrows in edge infos.
The handling of components in edge infos will be tackled in another PR


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No