### PR TITLE
[v3.4.0] Fix NAD side branch label arrows direction

### DIFF
--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -2208,8 +2208,12 @@ export class NetworkAreaDiagramViewer {
             typeof value === 'number'
                 ? value.toFixed(DiagramUtils.getEdgeInfoValuePrecision(edgeInfoMetadata.infoTypeB, this.svgParameters))
                 : value;
-        edgeInfoMetadata.direction = typeof value === 'number' ? DiagramUtils.getArrowDirection(value) : undefined;
-
+        if (!edgeInfoMetadata.direction) {
+            // set direction based on the value sign if missing
+            // Do not override edgeInfoMetadata.direction if present based on value sign
+            // Because it's ok to have a positive value and an IN direction
+            edgeInfoMetadata.direction = typeof value === 'number' ? DiagramUtils.getArrowDirection(value) : undefined;
+        }
         const edgeInfo = this.getOrCreateEdgeInfo(edgeInfoMetadata);
         if (!halfEdge.edgeInfoId) {
             halfEdge.edgeInfoId = edgeInfo.id;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
If `labelB` in edge infos metadata value is positive but `direction="IN"` then the previous behaviour was to override the arrow `direction`


**What is the new behavior (if this is a feature change)?**
We set the `direction` based on the value sign only if it's absent from the edge infos metadata.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
