### PR TITLE
[v3.4.0] fix middle arrow direction

### DIFF
--- a/packages/network-viewer-core/src/network-area-diagram-viewer/half-edge-utils.test.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/half-edge-utils.test.ts
@@ -115,14 +115,11 @@ test('getMiddleArrowRotation', () => {
         voltageLevelRadius: 0,
         edgePoints: [new Point(200, 0), new Point(100, 0)],
     };
-    expect(HalfEdgeUtils.getMiddleArrowRotation(halfEdge1, halfEdge2, 'OUT')).toBe(90);
-    expect(HalfEdgeUtils.getMiddleArrowRotation(halfEdge1, halfEdge2, 'IN')).toBe(-90);
+    expect(HalfEdgeUtils.getMiddleArrowRotation(halfEdge1, halfEdge2)).toBe(90);
 
-    expect(HalfEdgeUtils.getMiddleArrowRotation(halfEdge1, null, 'OUT')).toBe(90);
-    expect(HalfEdgeUtils.getMiddleArrowRotation(halfEdge1, null, 'IN')).toBe(-90);
+    expect(HalfEdgeUtils.getMiddleArrowRotation(halfEdge1, null)).toBe(90);
 
-    expect(HalfEdgeUtils.getMiddleArrowRotation(null, halfEdge2, 'OUT')).toBe(-270);
-    expect(HalfEdgeUtils.getMiddleArrowRotation(null, halfEdge2, 'IN')).toBe(-90);
+    expect(HalfEdgeUtils.getMiddleArrowRotation(null, halfEdge2)).toBe(-270);
 
     halfEdge1 = {
         side: '1',
@@ -139,8 +136,7 @@ test('getMiddleArrowRotation', () => {
         edgePoints: [new Point(200, 0), new Point(180, 100), new Point(120, 60), new Point(120, 100)],
     };
 
-    expect(HalfEdgeUtils.getMiddleArrowRotation(halfEdge1, halfEdge2, 'OUT')).toBe(0);
-    expect(HalfEdgeUtils.getMiddleArrowRotation(halfEdge1, halfEdge2, 'IN')).toBe(-180);
+    expect(HalfEdgeUtils.getMiddleArrowRotation(halfEdge1, halfEdge2)).toBe(0);
 });
 
 test('getInfoPointAndAngle', () => {

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/half-edge-utils.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/half-edge-utils.ts
@@ -42,11 +42,7 @@ export function getArrowEdgeAngle(halfEdge: HalfEdge): number {
         : getAngle(halfEdge.edgePoints[0], halfEdge.edgePoints[1]);
 }
 
-export function getMiddleArrowRotation(
-    halfEdge1: HalfEdge | null,
-    halfEdge2: HalfEdge | null,
-    direction: string
-): number {
+export function getMiddleArrowRotation(halfEdge1: HalfEdge | null, halfEdge2: HalfEdge | null): number {
     if (!halfEdge1 && !halfEdge2) return 0;
     const halfEdge = halfEdge1 ?? halfEdge2!;
     let angleMiddleArrow =
@@ -58,7 +54,9 @@ export function getMiddleArrowRotation(
             : getArrowEdgeAngle(halfEdge);
 
     angleMiddleArrow += angleMiddleArrow > Math.PI / 2 ? (-3 * Math.PI) / 2 : Math.PI / 2;
-    const flipArrow = halfEdge === halfEdge1 ? direction === 'IN' : direction === 'OUT';
+    // only the side-2 half edge has a reversed edge angle vs the canonical node1->node2
+    // direction, so flip it back; IN/OUT is already encoded by the arrow path shape
+    const flipArrow = !halfEdge1;
     return radToDeg(flipArrow ? angleMiddleArrow - Math.PI : angleMiddleArrow);
 }
 

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -1367,7 +1367,7 @@ export class NetworkAreaDiagramViewer {
         if (direction) {
             const arrowElement = edgeInfo.querySelector('path');
             if (arrowElement) {
-                const arrowAngle = HalfEdgeUtils.getMiddleArrowRotation(halfEdge1, halfEdge2, direction);
+                const arrowAngle = HalfEdgeUtils.getMiddleArrowRotation(halfEdge1, halfEdge2);
                 arrowElement.setAttribute('transform', `rotate(${DiagramUtils.getFormattedValue(arrowAngle)})`);
             }
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
The middle arrow of an edge is displayed in the wrong direction. The front-end recalculates the arrow rotation every time the diagram is updated (on init, on node move, on branch state update). The rotation was incorrectly computed using the IN/OUT direction from the metadata, but this direction is already encoded in the SVG arrow path shape itself — applying it again in the rotation caused the arrow to flip in certain cases.



**What is the new behavior (if this is a feature change)?**
The middle arrow rotation is now computed purely from the geometry of the half-edges. A 180° flip is applied only when halfEdge2 is used alone, to compensate for its reversed geometric convention relative to the canonical node1→node2 direction. The IN/OUT direction no longer influences the rotation calculation.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
