### PR TITLE
[nad-viewer] Fix text boxes creation in adaptive zoom

### DIFF
--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -1861,9 +1861,13 @@ export class NetworkAreaDiagramViewer {
 
         this.textNodesSection?.appendChild(newTextElement);
 
-        const newVlNameElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
-        newVlNameElement.textContent = textNode.equipmentId;
-        newDivElement.appendChild(newVlNameElement);
+        if (node.legendHeader) {
+            node.legendHeader.forEach((header) => {
+                newDivElement.appendChild(this.createTextHeader(header));
+            });
+        } else {
+            newDivElement.appendChild(this.createTextHeader(textNode.equipmentId));
+        }
 
         for (const busNode of busNodes) {
             const newBusDivElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
@@ -1881,6 +1885,12 @@ export class NetworkAreaDiagramViewer {
             newDivElement.appendChild(newBusDivElement);
         }
         return newTextElement;
+    }
+
+    private createTextHeader(header: string): HTMLElement {
+        const newHeaderElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+        newHeaderElement.textContent = header;
+        return newHeaderElement;
     }
 
     private createLegendEdge(textNode: TextNodeMetadata, busNodes: BusNodeMetadata[], node: NodeMetadata) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
In the NAD viewer, using the adaptice zoom functionality, in the creation of text boxes, the equipment id is used as text box header, instead of the legend headers defined in the diagram metadata, see below.

<img width="562" height="714" alt="text_box_header" src="https://github.com/user-attachments/assets/dafe9de5-40bd-4135-82b0-67ab06f36ea7" />



**What is the new behavior (if this is a feature change)?**
In the NAD viewer, using the adaptice zoom functionality, in the creation of text boxes, the legend headers defined in the diagram metadata are used as text box headers


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No