### PR TITLE
[nad-viewer] Add CSS classes to diagram elements in SVG creation from metadata

### DIFF
--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-utils.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-utils.ts
@@ -440,7 +440,7 @@ export function createTextNode(
     newTextElement.id = textNode.svgId;
 
     const newDivElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
-    newDivElement.classList.add('nad-label-box');
+    addCssClasses(newDivElement, node.classes, 'nad-label-box');
     newTextElement.appendChild(newDivElement);
 
     const newVlNameElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
@@ -453,7 +453,7 @@ export function createTextNode(
         newDivElement.appendChild(newBusDivElement);
 
         const newBusLegendElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'span');
-        newBusLegendElement.classList.add('nad-legend-square');
+        addCssClasses(newBusLegendElement, busNode.classes, 'nad-legend-square');
         newBusDivElement.appendChild(newBusLegendElement);
 
         const textNode = document.createTextNode(busNode.legend ?? '');
@@ -483,4 +483,13 @@ export function createTextEdge(
     newLegendEdgeElement.setAttribute('points', polyline);
 
     return newLegendEdgeElement;
+}
+
+export function addCssClasses(element: Element, cssClasses: string[] | undefined, elementCssClass?: string) {
+    cssClasses?.forEach((cssClass) => {
+        element.classList.add(cssClass);
+    });
+    if (elementCssClass) {
+        element.classList.add(elementCssClass);
+    }
 }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
@@ -122,6 +122,7 @@ export class SvgWriter {
         if (MetadataUtils.isBoundaryNode(node)) {
             gNodeElement.classList.add(SvgWriter.BOUNDARY_BUS_CLASS);
         }
+        SvgUtils.addCssClasses(gNodeElement, node.classes);
         gNodeElement.setAttribute(
             'transform',
             'translate(' + DiagramUtils.getFormattedPoint(new Point(node.x, node.y)) + ')'
@@ -154,7 +155,7 @@ export class SvgWriter {
         if (MetadataUtils.isBoundaryNode(node)) {
             const pathElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
             pathElement.id = busNode.svgId;
-            pathElement.classList.add(SvgWriter.BUS_CLASS);
+            SvgUtils.addCssClasses(pathElement, busNode.classes, SvgWriter.BUS_CLASS);
             const edges: EdgeMetadata[] = MetadataUtils.getNodeEdgesMetadata(node.svgId, this.diagramMetadata.edges);
             const edgeAngle = this.edgeRouter?.getEdgeAngle(edges[0].svgId, '2');
             const path: string = edgeAngle
@@ -165,13 +166,13 @@ export class SvgWriter {
         } else if (busNode.index == 0) {
             const circleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
             circleElement.id = busNode.svgId;
-            circleElement.classList.add(SvgWriter.BUS_CLASS);
+            SvgUtils.addCssClasses(circleElement, busNode.classes, SvgWriter.BUS_CLASS);
             circleElement.setAttribute('r', DiagramUtils.getFormattedValue(nodeRadius.busOuterRadius));
             return circleElement;
         } else {
             const pathElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
             pathElement.id = busNode.svgId;
-            pathElement.classList.add(SvgWriter.BUS_CLASS);
+            SvgUtils.addCssClasses(pathElement, busNode.classes, SvgWriter.BUS_CLASS);
             const edgeAngles = DiagramUtils.getSortedAnglesWithWrapAround(traversingBusEdgesAngles);
             const path: string = DiagramUtils.getFragmentedAnnulusPath(
                 edgeAngles,
@@ -244,14 +245,16 @@ export class SvgWriter {
         }
         const halfEdgePoints1 = this.edgeRouter?.getEdgePoints(edge.svgId, '1');
         if (halfEdgePoints1 && !edge.invisible1) {
-            gEdgeElement.appendChild(this.getHalfEdge(edge, halfEdgePoints1));
+            gEdgeElement.appendChild(this.getHalfEdge(edge, halfEdgePoints1, edge.classes1));
         }
         const halfEdgePoints2 = this.edgeRouter?.getEdgePoints(edge.svgId, '2');
         if (halfEdgePoints2 && !edge.invisible2) {
-            gEdgeElement.appendChild(this.getHalfEdge(edge, halfEdgePoints2));
+            gEdgeElement.appendChild(this.getHalfEdge(edge, halfEdgePoints2, edge.classes2));
         }
         if (DiagramUtils.isTransformerEdge(edgeType) && (halfEdgePoints1 || halfEdgePoints2)) {
-            gEdgeElement.appendChild(this.getTransformer(halfEdgePoints1, halfEdgePoints2, edgeType));
+            gEdgeElement.appendChild(
+                this.getTransformer(halfEdgePoints1, halfEdgePoints2, edgeType, edge.classes1, edge.classes2)
+            );
         }
         if (DiagramUtils.isHVDCLineEdge(edgeType) && halfEdgePoints1) {
             gEdgeElement.appendChild(this.getHVDCLine(halfEdgePoints1));
@@ -259,15 +262,19 @@ export class SvgWriter {
         return gEdgeElement;
     }
 
-    private getHalfEdge(edge: EdgeMetadata, points: Point[]): SVGPolylineElement | SVGPathElement {
+    private getHalfEdge(
+        edge: EdgeMetadata,
+        points: Point[],
+        cssClasses: string[] | undefined
+    ): SVGPolylineElement | SVGPathElement {
         if (edge.node1 == edge.node2) {
             const pathElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-            pathElement.classList.add(SvgWriter.EDGE_CLASS);
+            SvgUtils.addCssClasses(pathElement, cssClasses, SvgWriter.EDGE_CLASS);
             pathElement.setAttribute('d', DiagramUtils.getHalfLoopPath(points));
             return pathElement;
         } else {
             const polylineElement = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
-            polylineElement.classList.add(SvgWriter.EDGE_CLASS);
+            SvgUtils.addCssClasses(polylineElement, cssClasses, SvgWriter.EDGE_CLASS);
             polylineElement.setAttribute('points', DiagramUtils.getFormattedPolyline(points));
             return polylineElement;
         }
@@ -276,14 +283,16 @@ export class SvgWriter {
     private getTransformer(
         points1: Point[] | undefined,
         points2: Point[] | undefined,
-        edgeType: EdgeType
+        edgeType: EdgeType,
+        cssClasses1: string[] | undefined,
+        cssClasses2: string[] | undefined
     ): SVGGElement {
         const gTranformerElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         if (points1) {
-            gTranformerElement.appendChild(this.getTransformerWinding(points1));
+            gTranformerElement.appendChild(this.getTransformerWinding(points1, cssClasses1));
         }
         if (points2) {
-            gTranformerElement.appendChild(this.getTransformerWinding(points2));
+            gTranformerElement.appendChild(this.getTransformerWinding(points2, cssClasses2));
         }
         if (edgeType == EdgeType.PHASE_SHIFT_TRANSFORMER) {
             gTranformerElement.appendChild(this.getTransformerArrow(points1, points2));
@@ -291,9 +300,9 @@ export class SvgWriter {
         return gTranformerElement;
     }
 
-    private getTransformerWinding(points: Point[]): SVGCircleElement {
+    private getTransformerWinding(points: Point[], cssClasses: string[] | undefined): SVGCircleElement {
         const transformerCircleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-        transformerCircleElement.classList.add(SvgWriter.WINDING_CLASS);
+        SvgUtils.addCssClasses(transformerCircleElement, cssClasses, SvgWriter.WINDING_CLASS);
         const circleCenter = DiagramUtils.getPointAtDistance(
             points.at(-1)!,
             points.at(-2)!,
@@ -348,6 +357,7 @@ export class SvgWriter {
     private getThreeWTEdge(edge: EdgeMetadata, points: Point[]): SVGGElement {
         const gThreeWTEdgeElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         gThreeWTEdgeElement.id = edge.svgId;
+        SvgUtils.addCssClasses(gThreeWTEdgeElement, edge.classes1);
         gThreeWTEdgeElement.appendChild(this.getThreeWTPolyline(points));
         return gThreeWTEdgeElement;
     }
@@ -387,10 +397,15 @@ export class SvgWriter {
             const points = this.edgeRouter?.getThreeWTEdgePoints(twtEdge.svgId);
             if (points) {
                 const threeWTPoint: Point = new Point(threeWT.x, threeWT.y);
-                gThreeWTElement.appendChild(this.getThreeWTWinding(threeWTPoint, points));
+                gThreeWTElement.appendChild(this.getThreeWTWinding(threeWTPoint, points, twtEdge.classes1));
                 if (MetadataUtils.isPSThreeWTEdge(twtEdge)) {
                     gThreeWTElement.appendChild(
-                        this.getThreeWTArrow(threeWTPoint, points, twtEdge.side ?? this.windingSideMapping[index])
+                        this.getThreeWTArrow(
+                            threeWTPoint,
+                            points,
+                            twtEdge.side ?? this.windingSideMapping[index],
+                            twtEdge.classes1
+                        )
                     );
                 }
             }
@@ -398,9 +413,13 @@ export class SvgWriter {
         return gThreeWTElement;
     }
 
-    private getThreeWTWinding(threeWTPoint: Point, points: Point[]): SVGCircleElement {
+    private getThreeWTWinding(
+        threeWTPoint: Point,
+        points: Point[],
+        cssClasses: string[] | undefined
+    ): SVGCircleElement {
         const transformerCircleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-        transformerCircleElement.classList.add(SvgWriter.WINDING_CLASS);
+        SvgUtils.addCssClasses(transformerCircleElement, cssClasses, SvgWriter.WINDING_CLASS);
         const circleCenter = DiagramUtils.getPointAtDistance(
             points[1],
             threeWTPoint,
@@ -415,9 +434,14 @@ export class SvgWriter {
         return transformerCircleElement;
     }
 
-    private getThreeWTArrow(threeWTPoint: Point, points: Point[], side: string): SVGPathElement {
+    private getThreeWTArrow(
+        threeWTPoint: Point,
+        points: Point[],
+        side: string,
+        cssClasses: string[] | undefined
+    ): SVGPathElement {
         const arrowPathElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-        arrowPathElement.classList.add(SvgWriter.WINDING_CLASS);
+        SvgUtils.addCssClasses(arrowPathElement, cssClasses, SvgWriter.WINDING_CLASS);
         const matrix: string = DiagramUtils.getThreeWTArrowMatrixString(
             threeWTPoint,
             points,

--- a/packages/network-viewer-core/src/resources/test-data/nad-ieee14cdf-solved.svg
+++ b/packages/network-viewer-core/src/resources/test-data/nad-ieee14cdf-solved.svg
@@ -1,134 +1,134 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="-773.57 -909.23 1767.75 1528.47" xmlns="http://www.w3.org/2000/svg">
     <g class="nad-vl-nodes">
-        <g transform="translate(182.16,-669.23)" id="0">
-            <circle r="27.50" id="3" class="nad-busnode"/>
+        <g transform="translate(182.16,-669.23)" id="0" class="nad-vl0to30">
+            <circle r="27.50" id="3" class="nad-bus-0 nad-busnode"/>
         </g>
-        <g transform="translate(-573.57,100.52)" id="4">
-            <circle r="27.50" id="7" class="nad-busnode"/>
+        <g transform="translate(-573.57,100.52)" id="4" class="nad-vl0to30">
+            <circle r="27.50" id="7" class="nad-bus-0 nad-busnode"/>
         </g>
-        <g transform="translate(-295.68,308.31)" id="8">
-            <circle r="27.50" id="11" class="nad-busnode"/>
+        <g transform="translate(-295.68,308.31)" id="8" class="nad-vl0to30">
+            <circle r="27.50" id="11" class="nad-bus-0 nad-busnode"/>
         </g>
-        <g transform="translate(694.18,76.12)" id="12">
-            <circle r="27.50" id="15" class="nad-busnode"/>
+        <g transform="translate(694.18,76.12)" id="12" class="nad-vl0to30">
+            <circle r="27.50" id="15" class="nad-bus-0 nad-busnode"/>
         </g>
-        <g transform="translate(468.40,333.92)" id="16">
-            <circle r="27.50" id="19" class="nad-busnode"/>
+        <g transform="translate(468.40,333.92)" id="16" class="nad-vl0to30">
+            <circle r="27.50" id="19" class="nad-bus-0 nad-busnode"/>
         </g>
-        <g transform="translate(112.11,419.24)" id="20">
-            <circle r="27.50" id="23" class="nad-busnode"/>
+        <g transform="translate(112.11,419.24)" id="20" class="nad-vl0to30">
+            <circle r="27.50" id="23" class="nad-bus-0 nad-busnode"/>
         </g>
-        <g transform="translate(62.40,-384.58)" id="24">
-            <circle r="27.50" id="27" class="nad-busnode"/>
+        <g transform="translate(62.40,-384.58)" id="24" class="nad-vl0to30">
+            <circle r="27.50" id="27" class="nad-bus-0 nad-busnode"/>
         </g>
-        <g transform="translate(379.01,-360.27)" id="28">
-            <circle r="27.50" id="31" class="nad-busnode"/>
+        <g transform="translate(379.01,-360.27)" id="28" class="nad-vl0to30">
+            <circle r="27.50" id="31" class="nad-bus-0 nad-busnode"/>
         </g>
-        <g transform="translate(-140.21,-108.15)" id="32">
-            <circle r="17.50" id="36" class="nad-busnode"/>
-            <path d="M0.536,-37.496 A37.500,37.500 157.082 0 1 14.108,34.745 L11.161,19.537 A22.500,22.500 -141.803 0 0 3.310,-22.255 Z M-0.536,37.496 A37.500,37.500 119.772 0 1 -32.281,-19.084 L-20.719,-8.774 A22.500,22.500 -104.493 0 0 -3.310,22.255 Z " id="37" class="nad-busnode"/>
-            <path d="M-37.325,-43.739 A57.500,57.500 22.363 0 1 -17.877,-54.651 L-15.058,-39.743 A42.500,42.500 -17.088 0 0 -26.071,-33.564 Z M-3.176,-57.412 A57.500,57.500 105.053 0 1 56.267,11.844 L41.947,6.831 A42.500,42.500 -99.778 0 0 -0.392,-42.498 Z M51.309,25.955 A57.500,57.500 30.125 0 1 31.352,48.201 L24.788,34.522 A42.500,42.500 -24.849 0 0 37.001,20.909 Z M3.176,57.412 A57.500,57.500 45.053 0 1 -38.390,42.807 L-26.889,32.912 A42.500,42.500 -39.778 0 0 0.392,42.498 Z M-54.611,17.995 A57.500,57.500 52.815 0 1 -47.344,-32.632 L-36.066,-22.483 A42.500,42.500 -47.539 0 0 -40.934,11.429 Z " id="35" class="nad-busnode"/>
+        <g transform="translate(-140.21,-108.15)" id="32" class="nad-vl0to30">
+            <circle r="17.50" id="36" class="nad-bus-1 nad-busnode"/>
+            <path d="M0.536,-37.496 A37.500,37.500 157.082 0 1 14.108,34.745 L11.161,19.537 A22.500,22.500 -141.803 0 0 3.310,-22.255 Z M-0.536,37.496 A37.500,37.500 119.772 0 1 -32.281,-19.084 L-20.719,-8.774 A22.500,22.500 -104.493 0 0 -3.310,22.255 Z " id="37" class="nad-bus-2 nad-busnode"/>
+            <path d="M-37.325,-43.739 A57.500,57.500 22.363 0 1 -17.877,-54.651 L-15.058,-39.743 A42.500,42.500 -17.088 0 0 -26.071,-33.564 Z M-3.176,-57.412 A57.500,57.500 105.053 0 1 56.267,11.844 L41.947,6.831 A42.500,42.500 -99.778 0 0 -0.392,-42.498 Z M51.309,25.955 A57.500,57.500 30.125 0 1 31.352,48.201 L24.788,34.522 A42.500,42.500 -24.849 0 0 37.001,20.909 Z M3.176,57.412 A57.500,57.500 45.053 0 1 -38.390,42.807 L-26.889,32.912 A42.500,42.500 -39.778 0 0 0.392,42.498 Z M-54.611,17.995 A57.500,57.500 52.815 0 1 -47.344,-32.632 L-36.066,-22.483 A42.500,42.500 -47.539 0 0 -40.934,11.429 Z " id="35" class="nad-bus-0 nad-busnode"/>
         </g>
-        <g transform="translate(202.16,-30.06)" id="38">
-            <circle r="27.50" id="41" class="nad-busnode"/>
-            <path d="M-53.921,-19.968 A57.500,57.500 40.691 0 1 -27.866,-50.296 L-18.519,-26.708 A32.500,32.500 -29.193 0 0 -29.194,-14.282 Z M26.699,-50.926 A57.500,57.500 247.707 1 1 -57.247,-5.385 L-32.499,0.213 A32.500,32.500 -236.210 1 0 17.898,-27.128 Z " id="42" class="nad-busnode"/>
+        <g transform="translate(202.16,-30.06)" id="38" class="nad-vl0to30">
+            <circle r="27.50" id="41" class="nad-bus-0 nad-busnode"/>
+            <path d="M-53.921,-19.968 A57.500,57.500 40.691 0 1 -27.866,-50.296 L-18.519,-26.708 A32.500,32.500 -29.193 0 0 -29.194,-14.282 Z M26.699,-50.926 A57.500,57.500 247.707 1 1 -57.247,-5.385 L-32.499,0.213 A32.500,32.500 -236.210 1 0 17.898,-27.128 Z " id="42" class="nad-bus-1 nad-busnode"/>
         </g>
-        <g transform="translate(-520.85,-451.48)" id="43">
-            <circle r="27.50" id="46" class="nad-busnode"/>
+        <g transform="translate(-520.85,-451.48)" id="43" class="nad-vl0to30">
+            <circle r="27.50" id="46" class="nad-bus-0 nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="47">
-            <polyline class="nad-edge-path" points="171.49,-643.88 122.28,-526.91"/>
-            <polyline class="nad-edge-path" points="73.07,-409.93 122.28,-526.91"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="171.49,-643.88 122.28,-526.91"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="73.07,-409.93 122.28,-526.91"/>
         </g>
         <g id="48">
-            <polyline class="nad-edge-path" points="183.02,-641.74 192.16,-349.65"/>
-            <polyline class="nad-edge-path" points="201.30,-57.55 192.16,-349.65"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="183.02,-641.74 192.16,-349.65"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="201.30,-57.55 192.16,-349.65"/>
         </g>
         <g id="49">
-            <polyline class="nad-edge-path" points="-551.54,116.99 -434.62,204.42"/>
-            <polyline class="nad-edge-path" points="-317.70,291.84 -434.62,204.42"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="-551.54,116.99 -434.62,204.42"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="-317.70,291.84 -434.62,204.42"/>
         </g>
         <g id="50">
-            <polyline class="nad-edge-path" points="-174.00,-91.88 -361.39,-1.64"/>
-            <polyline class="nad-edge-path" points="-548.79,88.59 -361.39,-1.64"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="-174.00,-91.88 -361.39,-1.64"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="-548.79,88.59 -361.39,-1.64"/>
         </g>
         <g id="51">
-            <polyline class="nad-edge-path" points="154.60,2.26 -59.17,147.56"/>
-            <polyline class="nad-edge-path" points="-272.94,292.85 -59.17,147.56"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="154.60,2.26 -59.17,147.56"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="-272.94,292.85 -59.17,147.56"/>
         </g>
         <g id="52">
-            <polyline class="nad-edge-path" points="676.07,96.81 581.29,205.02"/>
-            <polyline class="nad-edge-path" points="486.52,313.23 581.29,205.02"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="676.07,96.81 581.29,205.02"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="486.52,313.23 581.29,205.02"/>
         </g>
         <g id="53">
-            <polyline class="nad-edge-path" points="258.36,-17.93 462.83,26.19"/>
-            <polyline class="nad-edge-path" points="667.30,70.32 462.83,26.19"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="258.36,-17.93 462.83,26.19"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="667.30,70.32 462.83,26.19"/>
         </g>
         <g id="54">
-            <polyline class="nad-edge-path" points="441.66,340.32 290.26,376.58"/>
-            <polyline class="nad-edge-path" points="138.86,412.83 290.26,376.58"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="441.66,340.32 290.26,376.58"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="138.86,412.83 290.26,376.58"/>
         </g>
         <g id="55">
-            <polyline class="nad-edge-path" points="236.11,16.34 344.14,164.03"/>
-            <polyline class="nad-edge-path" points="452.17,311.72 344.14,164.03"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="236.11,16.34 344.14,164.03"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="452.17,311.72 344.14,164.03"/>
         </g>
         <g id="56">
-            <polyline class="nad-edge-path" points="-124.03,-74.32 -11.89,160.06"/>
-            <polyline class="nad-edge-path" points="100.24,394.43 -11.89,160.06"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="-124.03,-74.32 -11.89,160.06"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="100.24,394.43 -11.89,160.06"/>
         </g>
         <g id="57">
-            <polyline class="nad-edge-path" points="89.82,-382.48 220.71,-372.43"/>
-            <polyline class="nad-edge-path" points="351.59,-362.38 220.71,-372.43"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="89.82,-382.48 220.71,-372.43"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="351.59,-362.38 220.71,-372.43"/>
         </g>
         <g id="58">
-            <polyline class="nad-edge-path" points="46.15,-362.40 -30.04,-258.46"/>
-            <polyline class="nad-edge-path" points="-106.22,-154.52 -30.04,-258.46"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="46.15,-362.40 -30.04,-258.46"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="-106.22,-154.52 -30.04,-258.46"/>
         </g>
         <g id="59">
-            <polyline class="nad-edge-path" points="72.49,-359.00 132.28,-207.32"/>
-            <polyline class="nad-edge-path" points="192.07,-55.65 132.28,-207.32"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="72.49,-359.00 132.28,-207.32"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="192.07,-55.65 132.28,-207.32"/>
         </g>
         <g id="60">
-            <polyline class="nad-edge-path" points="354.27,-348.26 132.89,-240.76"/>
-            <polyline class="nad-edge-path" points="-88.49,-133.26 132.89,-240.76"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="354.27,-348.26 132.89,-240.76"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="-88.49,-133.26 132.89,-240.76"/>
         </g>
         <g id="61">
-            <polyline class="nad-edge-path" points="-84.15,-95.36 45.60,-65.77"/>
-            <polyline class="nad-edge-path" points="175.35,-36.18 45.60,-65.77"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="-84.15,-95.36 45.60,-65.77"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="175.35,-36.18 45.60,-65.77"/>
         </g>
         <g id="62">
-            <polyline class="nad-edge-path" points="-153.20,-119.87 -326.82,-276.46"/>
-            <polyline class="nad-edge-path" points="-500.43,-433.06 -326.82,-276.46"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="-153.20,-119.87 -326.82,-276.46"/>
+            <polyline class="nad-vl0to30 nad-edge-path" points="-500.43,-433.06 -326.82,-276.46"/>
         </g>
         <g id="63">
-            <path class="nad-edge-path" d="M-136.98,-90.95 L-125.44,-29.52 C-118.05,9.79 -142.25,18.33 -179.99,5.07"/>
-            <path class="nad-edge-path" d="M-168.67,-83.72 L-200.92,-56.04 C-231.27,-29.99 -217.73,-8.19 -179.99,5.07"/>
+            <path class="nad-vl0to30 nad-edge-path" d="M-136.98,-90.95 L-125.44,-29.52 C-118.05,9.79 -142.25,18.33 -179.99,5.07"/>
+            <path class="nad-vl0to30 nad-edge-path" d="M-168.67,-83.72 L-200.92,-56.04 C-231.27,-29.99 -217.73,-8.19 -179.99,5.07"/>
         </g>
         <g id="64">
-            <path class="nad-edge-path" d="M-194.46,-127.21 L-215.69,-134.67 C-253.42,-147.93 -248.72,-173.15 -241.13,-179.67"/>
-            <path class="nad-edge-path" d="M-143.44,-125.35 L-154.98,-186.77 C-162.37,-226.08 -188.01,-225.26 -195.60,-218.74"/>
+            <path class="nad-vl0to30 nad-edge-path" d="M-194.46,-127.21 L-215.69,-134.67 C-253.42,-147.93 -248.72,-173.15 -241.13,-179.67"/>
+            <path class="nad-vl0to30 nad-edge-path" d="M-143.44,-125.35 L-154.98,-186.77 C-162.37,-226.08 -188.01,-225.26 -195.60,-218.74"/>
             <g>
-                <circle class="nad-winding" cx="-225.95" cy="-192.69" r="20.00"/>
-                <circle class="nad-winding" cx="-210.78" cy="-205.72" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="-225.95" cy="-192.69" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="-210.78" cy="-205.72" r="20.00"/>
             </g>
         </g>
         <g id="65">
-            <path class="nad-edge-path" d="M-96.58,-145.60 L-79.50,-160.25 C-49.15,-186.30 -29.66,-169.61 -27.81,-159.79"/>
-            <path class="nad-edge-path" d="M-104.83,-95.71 L-64.73,-81.63 C-27.00,-68.37 -14.89,-90.99 -16.73,-100.82"/>
+            <path class="nad-vl0to30 nad-edge-path" d="M-96.58,-145.60 L-79.50,-160.25 C-49.15,-186.30 -29.66,-169.61 -27.81,-159.79"/>
+            <path class="nad-vl0to30 nad-edge-path" d="M-104.83,-95.71 L-64.73,-81.63 C-27.00,-68.37 -14.89,-90.99 -16.73,-100.82"/>
             <g>
-                <circle class="nad-winding" cx="-24.12" cy="-140.13" r="20.00"/>
-                <circle class="nad-winding" cx="-20.43" cy="-120.47" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="-24.12" cy="-140.13" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="-20.43" cy="-120.47" r="20.00"/>
             </g>
         </g>
         <g id="66">
-            <path class="nad-edge-path" d="M211.65,-55.87 L229.77,-105.15 C243.58,-142.69 268.74,-137.62 275.14,-129.94"/>
-            <path class="nad-edge-path" d="M258.82,-39.86 L280.99,-43.69 C320.40,-50.50 319.95,-76.16 313.55,-83.84"/>
+            <path class="nad-vl0to30 nad-edge-path" d="M211.65,-55.87 L229.77,-105.15 C243.58,-142.69 268.74,-137.62 275.14,-129.94"/>
+            <path class="nad-vl0to30 nad-edge-path" d="M258.82,-39.86 L280.99,-43.69 C320.40,-50.50 319.95,-76.16 313.55,-83.84"/>
             <g>
-                <circle class="nad-winding" cx="287.94" cy="-114.57" r="20.00"/>
-                <circle class="nad-winding" cx="300.75" cy="-99.21" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="287.94" cy="-114.57" r="20.00"/>
+                <circle class="nad-vl0to30 nad-winding" cx="300.75" cy="-99.21" r="20.00"/>
             </g>
         </g>
     </g>
@@ -148,86 +148,86 @@
     </g>
     <g class="nad-text-nodes">
         <foreignObject id="1" y="-709.23" x="282.16" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-vl0to30 nad-label-box">
                 <div>VL1</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.1 kV / 0.0°</div>
+                    <span class="nad-bus-0 nad-legend-square"></span>1.1 kV / 0.0°</div>
             </div>
         </foreignObject>
         <foreignObject id="5" y="60.52" x="-473.57" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-vl0to30 nad-label-box">
                 <div>VL10</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.1 kV / -15.1°</div>
+                    <span class="nad-bus-0 nad-legend-square"></span>1.1 kV / -15.1°</div>
             </div>
         </foreignObject>
         <foreignObject id="9" y="268.31" x="-195.68" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-vl0to30 nad-label-box">
                 <div>VL11</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.1 kV / -14.8°</div>
+                    <span class="nad-bus-0 nad-legend-square"></span>1.1 kV / -14.8°</div>
             </div>
         </foreignObject>
         <foreignObject id="13" y="36.12" x="794.18" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-vl0to30 nad-label-box">
                 <div>VL12</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.1 kV / -15.1°</div>
+                    <span class="nad-bus-0 nad-legend-square"></span>1.1 kV / -15.1°</div>
             </div>
         </foreignObject>
         <foreignObject id="17" y="293.92" x="568.40" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-vl0to30 nad-label-box">
                 <div>VL13</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.1 kV / -15.2°</div>
+                    <span class="nad-bus-0 nad-legend-square"></span>1.1 kV / -15.2°</div>
             </div>
         </foreignObject>
         <foreignObject id="21" y="379.24" x="212.11" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-vl0to30 nad-label-box">
                 <div>VL14</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.0 kV / -16.0°</div>
+                    <span class="nad-bus-0 nad-legend-square"></span>1.0 kV / -16.0°</div>
             </div>
         </foreignObject>
         <foreignObject id="25" y="-424.58" x="162.40" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-vl0to30 nad-label-box">
                 <div>VL2</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.0 kV / -5.0°</div>
+                    <span class="nad-bus-0 nad-legend-square"></span>1.0 kV / -5.0°</div>
             </div>
         </foreignObject>
         <foreignObject id="29" y="-400.27" x="479.01" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-vl0to30 nad-label-box">
                 <div>VL3</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.0 kV / -12.7°</div>
+                    <span class="nad-bus-0 nad-legend-square"></span>1.0 kV / -12.7°</div>
             </div>
         </foreignObject>
         <foreignObject id="33" y="-148.15" x="-40.21" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-vl0to30 nad-label-box">
                 <div>VL4</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.1 kV / -13.4°</div>
+                    <span class="nad-bus-1 nad-legend-square"></span>1.1 kV / -13.4°</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.1 kV / -14.9°</div>
+                    <span class="nad-bus-2 nad-legend-square"></span>1.1 kV / -14.9°</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.0 kV / -10.3°</div>
+                    <span class="nad-bus-0 nad-legend-square"></span>1.0 kV / -10.3°</div>
             </div>
         </foreignObject>
         <foreignObject id="39" y="-70.06" x="302.16" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-vl0to30 nad-label-box">
                 <div>VL5</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.0 kV / -8.8°</div>
+                    <span class="nad-bus-0 nad-legend-square"></span>1.0 kV / -8.8°</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.1 kV / -14.2°</div>
+                    <span class="nad-bus-1 nad-legend-square"></span>1.1 kV / -14.2°</div>
             </div>
         </foreignObject>
         <foreignObject id="44" y="-491.48" x="-420.85" height="1" width="1">
-            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-label-box">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="nad-vl0to30 nad-label-box">
                 <div>VL8</div>
                 <div class="nad-bus-descr">
-                    <span class="nad-legend-square"></span>1.1 kV / -13.4°</div>
+                    <span class="nad-bus-0 nad-legend-square"></span>1.1 kV / -13.4°</div>
             </div>
         </foreignObject>
     </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
feature



**What is the current behavior?**
In the NAD viewer, the SVG writer that creates the SVG starting from diagram metadata does not add all the CSS classes to the SVG elements



**What is the new behavior (if this is a feature change)?**
In the NAD viewer, the SVG writer that creates the SVG starting from diagram metadata adds all the CSS classes to the SVG elements



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No