### PR TITLE
[nad-viewer] Add edge info components in SVG creation from metadata

### DIFF
--- a/demo/nad-created.html
+++ b/demo/nad-created.html
@@ -113,16 +113,25 @@
                     <figcaption>Edge info with double arrows from metadata</figcaption>
                     <div id="svg-container-nad-double-arrows-c"></div>
                 </figure>
+                <div class="break"></div>
+                <figure class="diagram-figure">
+                    <figcaption>Edge info with components</figcaption>
+                    <div id="svg-container-nad-components"></div>
+                </figure>
+                <figure class="diagram-figure">
+                    <figcaption>Edge info with components from metadata</figcaption>
+                    <div id="svg-container-nad-components-c"></div>
+                </figure>
+                <div class="break"></div>
                 <figure class="diagram-figure">
                     <figcaption>Pegase network</figcaption>
                     <div id="svg-container-nad-pegase-network"></div>
                 </figure>
                 <div class="break"></div>
                 <figure class="diagram-figure">
-                    <figcaption>Pegase network from metadafra</figcaption>
+                    <figcaption>Pegase network from metadata</figcaption>
                     <div id="svg-container-nad-pegase-network-c"></div>
                 </figure>
-                <div class="break"></div>
             </div>
         </div>
         <script type="module" src="./src/nad-created.ts"></script>

--- a/demo/src/nad-created.ts
+++ b/demo/src/nad-created.ts
@@ -26,6 +26,8 @@ import NadSvgPegaseNetworkExample from './diagram-viewers/data/case1354pegase.sv
 import NadSvgPegaseNetworkExampleMeta from './diagram-viewers/data/case1354pegase_metadata.json';
 import NadSvgDoubleArrowsExample from './diagram-viewers/data/nad-double-arrows-with-middle-values.svg';
 import NadSvgDoubleArrowsExampleMeta from './diagram-viewers/data/nad-double-arrows-with-middle-values_metadata.json';
+import NadSvgComponentsExample from './diagram-viewers/data/nad-edge-info-components.svg';
+import NadSvgComponentsExampleMeta from './diagram-viewers/data/nad-edge-info-components_metadata.json';
 
 import { NadViewerParametersOptions, NetworkAreaDiagramViewer } from '../../src';
 import {
@@ -68,6 +70,7 @@ const addCreatedNadToDemo = () => {
         onToggleHoverCallback: handleToggleNadHover,
         onRightClickCallback: handleRightClick,
         onBendLineCallback: handleLineBending,
+        createSvgFromMetadata: true,
     };
     new NetworkAreaDiagramViewer(
         document.getElementById('svg-container-nad-eurostag-c')!,
@@ -304,6 +307,35 @@ const addCreatedNadToDemo = () => {
         nadViewerParametersOptions
     );
 
+    fetch(NadSvgComponentsExample)
+        .then((response) => response.text())
+        .then((svgContent) => {
+            const nadViewerParametersOptions: NadViewerParametersOptions = {
+                enableDragInteraction: true,
+                addButtons: true,
+                onMoveNodeCallback: handleNodeMove,
+                onMoveTextNodeCallback: handleTextNodeMove,
+                onSelectNodeCallback: handleNodeSelect,
+                onToggleHoverCallback: handleToggleNadHover,
+                onRightClickCallback: handleRightClick,
+                onBendLineCallback: handleLineBending,
+                adaptiveTextZoom: { enabled: true, threshold: 1100 },
+            };
+            new NetworkAreaDiagramViewer(
+                document.getElementById('svg-container-nad-components')!,
+                svgContent,
+                NadSvgComponentsExampleMeta,
+                nadViewerParametersOptions
+            );
+        });
+
+    new NetworkAreaDiagramViewer(
+        document.getElementById('svg-container-nad-components-c')!,
+        '',
+        NadSvgComponentsExampleMeta,
+        nadViewerParametersOptions
+    );
+
     fetch(NadSvgPegaseNetworkExample)
         .then((response) => response.text())
         .then((svgContent) => {
@@ -336,6 +368,7 @@ const addCreatedNadToDemo = () => {
         onToggleHoverCallback: handleToggleNadHover,
         onRightClickCallback: handleRightClick,
         onBendLineCallback: handleLineBending,
+        createSvgFromMetadata: true,
     };
     new NetworkAreaDiagramViewer(
         document.getElementById('svg-container-nad-pegase-network-c')!,

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/nad-viewer-parameters.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/nad-viewer-parameters.ts
@@ -135,6 +135,9 @@ export interface NadViewerParametersOptions {
     // Resolver that maps an SVG filename to its URL, for use with a custom component library.
     // If not provided, the default library SVG files are used.
     svgUrlResolver?: (fileName: string) => string;
+
+    // Whether create the SVG from diagram metadata, instead of using the SVG content provided as input
+    createSvgFromMetadata?: boolean;
 }
 
 export class NadViewerParameters {
@@ -149,6 +152,7 @@ export class NadViewerParameters {
     static readonly HOVER_POSITION_PRECISION_DEFAULT = 10;
     static readonly ENABLE_ADAPTIVE_ZOOM_DEFAULT = false;
     static readonly THRESHOLD_ADAPTIVE_ZOOM_DEFAULT = 3000;
+    static readonly CREATE_SVG_FROM_METADATA_DEFAULT = false;
 
     nadViewerParametersOptions: NadViewerParametersOptions | undefined;
 
@@ -231,5 +235,12 @@ export class NadViewerParameters {
 
     public getSvgUrlResolver(): ((fileName: string) => string) | undefined {
         return this.nadViewerParametersOptions?.svgUrlResolver;
+    }
+
+    public getCreateSvgFromMetadata(): boolean {
+        return (
+            this.nadViewerParametersOptions?.createSvgFromMetadata ??
+            NadViewerParameters.CREATE_SVG_FROM_METADATA_DEFAULT
+        );
     }
 }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/nad-viewer-parameters.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/nad-viewer-parameters.ts
@@ -136,7 +136,7 @@ export interface NadViewerParametersOptions {
     // If not provided, the default library SVG files are used.
     svgUrlResolver?: (fileName: string) => string;
 
-    // Whether create the SVG from diagram metadata, instead of using the SVG content provided as input
+    // Whether to create the SVG from diagram metadata, instead of using the SVG content provided as input
     createSvgFromMetadata?: boolean;
 }
 

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -150,6 +150,8 @@ export class NetworkAreaDiagramViewer {
 
     componentLibrary: LibraryComponent[] = DefaultLibraryComponents;
 
+    svgWriter: SvgWriter | undefined = undefined;
+
     static readonly ZOOM_CLASS_PREFIX = 'nad-zoom-';
 
     /**
@@ -169,11 +171,11 @@ export class NetworkAreaDiagramViewer {
         this.svgDiv.id = 'svg-container';
         this.svgContent = svgContent;
         this.diagramMetadata = diagramMetadata;
-        if (this.diagramMetadata != null && this.svgContent.length == 0) {
-            const createdSvg = new SvgWriter(this.diagramMetadata).getSvg();
-            this.svgContent = createdSvg;
-        }
         this.nadViewerParameters = new NadViewerParameters(nadViewerParametersOptions ?? undefined);
+        if (this.nadViewerParameters.getCreateSvgFromMetadata() && this.diagramMetadata != null) {
+            this.svgWriter = new SvgWriter(this.diagramMetadata);
+            this.svgContent = this.svgWriter.getEmptySvg();
+        }
         this.width = 0;
         this.height = 0;
         this.originalWidth = 0;
@@ -378,6 +380,9 @@ export class NetworkAreaDiagramViewer {
         };
         this.svgDraw = SVG().addTo(this.svgDiv).size(this.width, this.height).viewbox(viewBox);
         this.innerSvg = <SVGElement>this.svgDraw.svg(this.svgContent).node.firstElementChild;
+        if (this.nadViewerParameters.getCreateSvgFromMetadata()) {
+            this.svgWriter?.addSvgContent(<SVGSVGElement>this.innerSvg);
+        }
         this.innerSvg.style.overflow = 'visible';
 
         this.textNodesSection = this.getOrCreateTextNodesSection();
@@ -386,49 +391,7 @@ export class NetworkAreaDiagramViewer {
 
         // add events
         const hasMetadata = this.diagramMetadata !== null;
-        if (this.hasNodeInteraction() && hasMetadata) {
-            this.svgDraw.on('mousedown', (e: Event) => {
-                if ((e as MouseEvent).button == 0) {
-                    this.onMouseLeftDown(e as MouseEvent);
-                }
-            });
-            this.svgDraw.on('mousemove', (e: Event) => {
-                this.onMouseMove(e as MouseEvent);
-            });
-            this.svgDraw.on('mouseup mouseleave', (e: Event) => {
-                if ((e as MouseEvent).button == 0) {
-                    this.onMouseLeftUpOrLeave(e as MouseEvent);
-                }
-            });
-        }
-        if (hasMetadata) {
-            this.svgDraw.on('mouseover', (e: Event) => {
-                this.onHover(e as MouseEvent);
-            });
-
-            this.svgDraw.on('mouseout', () => {
-                this.clearHighlights();
-                this.hideEdgePreviewPoints();
-            });
-        }
-        if (this.onRightClickCallback != null && hasMetadata) {
-            this.svgDraw.on('mousedown', (e: Event) => {
-                if ((e as MouseEvent).button == 2) {
-                    this.onMouseRightDown(e as MouseEvent);
-                }
-            });
-        }
-
-        this.svgDraw.on('panStart', () => {
-            this.attachCursorOverlay('move');
-        });
-        this.svgDraw.on('panEnd', () => {
-            this.detachCursorOverlay();
-            //if the adaptive zoom feature is enabled, updates the diagram
-            if (this.nadViewerParameters.getAdaptiveTextZoom().enabled) {
-                this.adaptiveZoomViewboxUpdate(this.getCurrentlyMaxDisplayedSize());
-            }
-        });
+        this.addEvents(this.svgDraw, this.innerSvg, hasMetadata);
 
         // add pan and zoom to the SVG
         // we check if there is an "initial zoom" by checking ratio of width and height of the nad compared with viewBox sizes
@@ -485,6 +448,53 @@ export class NetworkAreaDiagramViewer {
                 emptyElement.style.fill = '#0000';
             });
         }
+    }
+
+    private addEvents(svgDraw: Svg, drawnSvg: SVGElement, hasMetadata: boolean) {
+        if (this.hasNodeInteraction() && hasMetadata) {
+            svgDraw.on('mousedown', (e: Event) => {
+                if ((e as MouseEvent).button == 0) {
+                    this.onMouseLeftDown(e as MouseEvent);
+                }
+            });
+            svgDraw.on('mousemove', (e: Event) => {
+                this.onMouseMove(e as MouseEvent);
+            });
+            svgDraw.on('mouseup mouseleave', (e: Event) => {
+                if ((e as MouseEvent).button == 0) {
+                    this.onMouseLeftUpOrLeave(e as MouseEvent);
+                }
+            });
+        }
+        if (hasMetadata) {
+            svgDraw.on('mouseover', (e: Event) => {
+                this.onHover(e as MouseEvent);
+            });
+
+            svgDraw.on('mouseout', () => {
+                this.clearHighlights();
+                this.hideEdgePreviewPoints();
+            });
+        }
+        if (this.onRightClickCallback != null && hasMetadata) {
+            svgDraw.on('mousedown', (e: Event) => {
+                if ((e as MouseEvent).button == 2) {
+                    this.onMouseRightDown(e as MouseEvent);
+                }
+            });
+        }
+
+        svgDraw.on('panStart', () => {
+            this.attachCursorOverlay('move');
+        });
+        svgDraw.on('panEnd', () => {
+            this.detachCursorOverlay();
+
+            //if the adaptive zoom feature is enabled, updates the diagram
+            if (this.nadViewerParameters.getAdaptiveTextZoom().enabled) {
+                this.adaptiveZoomViewboxUpdate(this.getCurrentlyMaxDisplayedSize());
+            }
+        });
     }
 
     private getOrCreateTextNodesSection(): SVGElement {

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -172,8 +172,13 @@ export class NetworkAreaDiagramViewer {
         this.svgContent = svgContent;
         this.diagramMetadata = diagramMetadata;
         this.nadViewerParameters = new NadViewerParameters(nadViewerParametersOptions ?? undefined);
+        this.componentLibrary = this.nadViewerParameters.getComponentLibrary() ?? DefaultLibraryComponents;
         if (this.nadViewerParameters.getCreateSvgFromMetadata() && this.diagramMetadata != null) {
-            this.svgWriter = new SvgWriter(this.diagramMetadata);
+            this.svgWriter = new SvgWriter(
+                this.diagramMetadata,
+                this.componentLibrary,
+                this.nadViewerParameters.getSvgUrlResolver()
+            );
             this.svgContent = this.svgWriter.getEmptySvg();
         }
         this.width = 0;
@@ -195,7 +200,6 @@ export class NetworkAreaDiagramViewer {
         this.init();
         this.layoutParameters = new LayoutParameters(this.diagramMetadata?.layoutParameters);
         this.previousMaxDisplayedSize = 0;
-        this.componentLibrary = this.nadViewerParameters.getComponentLibrary() ?? DefaultLibraryComponents;
     }
 
     public setWidth(width: number): void {
@@ -380,8 +384,8 @@ export class NetworkAreaDiagramViewer {
         };
         this.svgDraw = SVG().addTo(this.svgDiv).size(this.width, this.height).viewbox(viewBox);
         this.innerSvg = <SVGElement>this.svgDraw.svg(this.svgContent).node.firstElementChild;
-        if (this.nadViewerParameters.getCreateSvgFromMetadata()) {
-            this.addSvgContent(this.svgWriter, this.innerSvg);
+        if (this.svgWriter != null) {
+            this.svgWriter.addSvgContent(<SVGSVGElement>this.innerSvg);
         }
         this.innerSvg.style.overflow = 'visible';
 
@@ -448,20 +452,6 @@ export class NetworkAreaDiagramViewer {
                 emptyElement.style.fill = '#0000';
             });
         }
-    }
-
-    private addSvgContent(svgWriter: SvgWriter | undefined, svgElement: SVGElement) {
-        if (svgWriter === undefined) {
-            console.warn(
-                '[NAD] createSvgFromMetadata is true but no SvgWriter was created (diagramMetadata may be null).'
-            );
-            return;
-        }
-        if (!(svgElement instanceof SVGSVGElement)) {
-            console.error('[NAD] Expected SVGSVGElement for addSvgContent, got:', svgElement);
-            return;
-        }
-        svgWriter.addSvgContent(svgElement);
     }
 
     private addEvents(svgDraw: Svg, hasMetadata: boolean) {

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -381,7 +381,7 @@ export class NetworkAreaDiagramViewer {
         this.svgDraw = SVG().addTo(this.svgDiv).size(this.width, this.height).viewbox(viewBox);
         this.innerSvg = <SVGElement>this.svgDraw.svg(this.svgContent).node.firstElementChild;
         if (this.nadViewerParameters.getCreateSvgFromMetadata()) {
-            this.svgWriter?.addSvgContent(<SVGSVGElement>this.innerSvg);
+            this.addSvgContent(this.svgWriter, this.innerSvg);
         }
         this.innerSvg.style.overflow = 'visible';
 
@@ -391,7 +391,7 @@ export class NetworkAreaDiagramViewer {
 
         // add events
         const hasMetadata = this.diagramMetadata !== null;
-        this.addEvents(this.svgDraw, this.innerSvg, hasMetadata);
+        this.addEvents(this.svgDraw, hasMetadata);
 
         // add pan and zoom to the SVG
         // we check if there is an "initial zoom" by checking ratio of width and height of the nad compared with viewBox sizes
@@ -450,7 +450,21 @@ export class NetworkAreaDiagramViewer {
         }
     }
 
-    private addEvents(svgDraw: Svg, drawnSvg: SVGElement, hasMetadata: boolean) {
+    private addSvgContent(svgWriter: SvgWriter | undefined, svgElement: SVGElement) {
+        if (svgWriter === undefined) {
+            console.warn(
+                '[NAD] createSvgFromMetadata is true but no SvgWriter was created (diagramMetadata may be null).'
+            );
+            return;
+        }
+        if (!(svgElement instanceof SVGSVGElement)) {
+            console.error('[NAD] Expected SVGSVGElement for addSvgContent, got:', svgElement);
+            return;
+        }
+        svgWriter.addSvgContent(svgElement);
+    }
+
+    private addEvents(svgDraw: Svg, hasMetadata: boolean) {
         if (this.hasNodeInteraction() && hasMetadata) {
             svgDraw.on('mousedown', (e: Event) => {
                 if ((e as MouseEvent).button == 0) {

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-utils.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-utils.ts
@@ -443,9 +443,13 @@ export function createTextNode(
     addCssClasses(newDivElement, node.classes, 'nad-label-box');
     newTextElement.appendChild(newDivElement);
 
-    const newVlNameElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
-    newVlNameElement.textContent = textNode.equipmentId;
-    newDivElement.appendChild(newVlNameElement);
+    if (node.legendHeader) {
+        node.legendHeader.forEach((header) => {
+            newDivElement.appendChild(createTextHeader(header));
+        });
+    } else {
+        newDivElement.appendChild(createTextHeader(textNode.equipmentId));
+    }
 
     for (const busNode of busNodes) {
         const newBusDivElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
@@ -461,6 +465,12 @@ export function createTextNode(
     }
 
     return newTextElement;
+}
+
+function createTextHeader(header: string) {
+    const newHeaderElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
+    newHeaderElement.textContent = header;
+    return newHeaderElement;
 }
 
 export function createTextEdge(

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
@@ -74,11 +74,18 @@ export class SvgWriter {
     }
 
     public getEmptySvg(): string {
-        const baseSvg = this.createBaseSvg();
-        return new XMLSerializer().serializeToString(baseSvg.xmlDoc);
+        const vb = MetadataUtils.getViewBox(
+            this.diagramMetadata.nodes,
+            this.diagramMetadata.textNodes,
+            this.svgParameters
+        );
+        return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${vb.x} ${vb.y} ${vb.width} ${vb.height}"></svg>`;
     }
 
-    public createBaseSvg(textBoxSize?: { width: number; height: number }): { xmlDoc: XMLDocument; svg: SVGSVGElement } {
+    private createBaseSvg(textBoxSize?: { width: number; height: number }): {
+        xmlDoc: XMLDocument;
+        svg: SVGSVGElement;
+    } {
         // create XML doc
         const xmlDoc = this.getXmlDoc();
         // add SVG root element

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
@@ -14,6 +14,9 @@ import * as MetadataUtils from './metadata-utils';
 import { EdgeRouter } from './edge-router';
 import { EdgeType } from './diagram-types';
 import * as SvgUtils from './svg-utils';
+import { LibraryComponent } from './library-component';
+import DefaultLibraryComponents from '../resources/default-library/components.json';
+import * as ComponentUtils from './component-utils';
 
 export class SvgWriter {
     static readonly NODES_CLASS = 'nad-vl-nodes';
@@ -44,20 +47,47 @@ export class SvgWriter {
         2: 'TWO',
         3: 'THREE',
     };
+    componentLibrary: LibraryComponent[] = DefaultLibraryComponents;
+    urlResolver: ((fileName: string) => string) | undefined = undefined;
 
-    constructor(diagramMetadata: DiagramMetadata) {
+    constructor(
+        diagramMetadata: DiagramMetadata,
+        componentLibrary?: LibraryComponent[],
+        urlResolver?: (fileName: string) => string
+    ) {
         this.diagramMetadata = diagramMetadata;
         this.svgParameters = new SvgParameters(this.diagramMetadata.svgParameters);
+        if (componentLibrary) {
+            this.componentLibrary = componentLibrary;
+        }
+        if (urlResolver) {
+            this.urlResolver = urlResolver;
+        }
+        // get edge router, for computing edges points
+        this.edgeRouter = new EdgeRouter(this.diagramMetadata);
     }
 
     public getSvg(textBoxSize?: { width: number; height: number }): string {
-        // get edge router, for computing edges points
-        this.edgeRouter = new EdgeRouter(this.diagramMetadata);
+        const baseSvg = this.createBaseSvg(textBoxSize);
+        this.addSvgContent(baseSvg.svg);
+        return new XMLSerializer().serializeToString(baseSvg.xmlDoc);
+    }
+
+    public getEmptySvg(): string {
+        const baseSvg = this.createBaseSvg();
+        return new XMLSerializer().serializeToString(baseSvg.xmlDoc);
+    }
+
+    public createBaseSvg(textBoxSize?: { width: number; height: number }): { xmlDoc: XMLDocument; svg: SVGSVGElement } {
         // create XML doc
         const xmlDoc = this.getXmlDoc();
         // add SVG root element
         const svg = this.getSvgRootElement(textBoxSize);
         xmlDoc.appendChild(svg);
+        return { xmlDoc, svg };
+    }
+
+    public addSvgContent(svg: SVGSVGElement) {
         // add nodes
         svg.appendChild(this.getNodes());
         // add edges and infos
@@ -76,7 +106,6 @@ export class SvgWriter {
         const textNodeAndEdges = this.getTextNodesAndEdges();
         svg.appendChild(textNodeAndEdges.textEdges);
         svg.appendChild(textNodeAndEdges.textNodes);
-        return new XMLSerializer().serializeToString(xmlDoc);
     }
 
     private getXmlDoc(): XMLDocument {
@@ -461,8 +490,12 @@ export class SvgWriter {
         if (infoPoint) {
             gEdgeInfoElement.setAttribute('transform', 'translate(' + DiagramUtils.getFormattedPoint(infoPoint) + ')');
         }
-        // add arrows
-        this.addEdgeInfoArrows(gEdgeInfoElement, info, this.edgeRouter?.getEdgeSideInfoAngle(edge.svgId, side));
+        if (info.componentType) {
+            gEdgeInfoElement.appendChild(this.getEdgeInfoComponent(info.componentType));
+        } else {
+            // add arrows
+            this.addEdgeInfoArrows(gEdgeInfoElement, info, this.edgeRouter?.getEdgeSideInfoAngle(edge.svgId, side));
+        }
         // add labels
         const labelData = this.edgeRouter?.getEdgeSideLabelData(edge.svgId, side);
         if (labelData === undefined) return gEdgeInfoElement;
@@ -493,6 +526,22 @@ export class SvgWriter {
             );
         }
         return gEdgeInfoElement;
+    }
+
+    private getEdgeInfoComponent(componentType: string): SVGGElement {
+        const component = ComponentUtils.getComponent(this.componentLibrary, componentType);
+        const edgeInfoComponent = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        if (component) {
+            const trans = new Point(-component.size.width / 2, -component.size.height / 2);
+            edgeInfoComponent.setAttribute('transform', 'translate(' + DiagramUtils.getFormattedPoint(trans) + ')');
+            edgeInfoComponent.classList.add(component.styleClass);
+            component.subComponents.forEach((subComponent) => {
+                void ComponentUtils.getComponentPath(subComponent.fileName, this.urlResolver).then((path) => {
+                    edgeInfoComponent.appendChild(path);
+                });
+            });
+        }
+        return edgeInfoComponent;
     }
 
     private addEdgeInfoArrows(
@@ -576,8 +625,12 @@ export class SvgWriter {
                 'translate(' + DiagramUtils.getFormattedPoint(middleInfoPoint) + ')'
             );
         }
-        // add arrows
-        this.addEdgeInfoArrows(gEdgeMiddleInfoElement, info, this.edgeRouter?.getEdgeMiddleInfoAngle(edge.svgId));
+        if (info.componentType) {
+            gEdgeMiddleInfoElement.appendChild(this.getEdgeInfoComponent(info.componentType));
+        } else {
+            // add arrows
+            this.addEdgeInfoArrows(gEdgeMiddleInfoElement, info, this.edgeRouter?.getEdgeMiddleInfoAngle(edge.svgId));
+        }
         // add labels
         let x = 0;
         let style: string | undefined = 'text-anchor:middle';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
feature



**What is the current behavior?**
In the NAD viewer, the SVG writer that creates the SVG starting from diagram metadata does not handle components in edge infos



**What is the new behavior (if this is a feature change)?**
In the NAD viewer, the SVG writer that creates the SVG starting from diagram metadata handles components in edge infos


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
The creation of the SVG from metadata  was previously done in a single step: the SVG was created and provided to the viewer, in the constructor, for the parsing and visualization.
The creation  is now done in 2 steps: 
- the first step creates an empty SVG, with the correct viewbox, to be provided to the viewer for the parsing
- the second step adds all the content to the DOM element handled by the viewer

So the SVG writer methods has been changed for implementing these 2 steps, even if the old single step method is still available.
This changes were done for handling the asynchronous loading of the components.
A new parameter for choosing the creation of the SVG from the diagram metadata has been added to the NAD parameters

