### PR TITLE
Add voltage-level class to edge infos from metadata

### DIFF
--- a/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-metadata.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-metadata.ts
@@ -161,5 +161,4 @@ export interface EdgeInfoMetadata {
     labelA?: string;
     labelB?: string;
     componentType?: string;
-    classes?: string[];
 }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-metadata.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-metadata.ts
@@ -161,4 +161,5 @@ export interface EdgeInfoMetadata {
     labelA?: string;
     labelB?: string;
     componentType?: string;
+    classes?: string[];
 }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -379,6 +379,9 @@ export class NetworkAreaDiagramViewer {
         this.textEdgesSection = this.getOrCreateTextEdgesSection();
         this.edgeInfosSection = this.getOrCreateEdgeInfosSection();
 
+        // Tag the server-rendered edge infos with their side's voltage-level class
+        this.addClassesToEdgeInfos();
+
         // add events
         const hasMetadata = this.diagramMetadata !== null;
         if (this.hasNodeInteraction() && hasMetadata) {
@@ -1911,6 +1914,25 @@ export class NetworkAreaDiagramViewer {
         return <SVGElement>this.edgeInfosSection?.querySelector(":scope > [id='" + edgeInfoSvgId + "']") ?? null;
     }
 
+    // Apply the edge info metadata classes (e.g. its side's voltage-level class) on the matching SVG element
+    private addClassesToEdgeInfos(): void {
+        this.diagramMetadata?.edges.forEach((edge) => {
+            this.addClassesToEdgeInfo(edge.edgeInfo1);
+            this.addClassesToEdgeInfo(edge.edgeInfo2);
+            this.addClassesToEdgeInfo(edge.edgeInfoMiddle);
+        });
+        this.diagramMetadata?.injections?.forEach((injection) => {
+            this.addClassesToEdgeInfo(injection.edgeInfo);
+        });
+    }
+
+    private addClassesToEdgeInfo(edgeInfoMetadata: EdgeInfoMetadata | undefined): void {
+        if (!edgeInfoMetadata?.classes?.length) {
+            return;
+        }
+        this.getEdgeInfo(edgeInfoMetadata.svgId)?.classList.add(...edgeInfoMetadata.classes);
+    }
+
     private hasTextNode(textNode: TextNodeMetadata) {
         return !!this.textNodesSection?.querySelector(":scope > [id='" + textNode.svgId + "']");
     }
@@ -2480,6 +2502,11 @@ export class NetworkAreaDiagramViewer {
 
         const newEdgeInfo = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         newEdgeInfo.id = edgeInfoMetadata.svgId;
+        // Re-apply the side's voltage-level class(es) when the edge info is recreated (e.g. adaptive
+        // zoom), so it stays hidden consistently with its voltage level.
+        if (edgeInfoMetadata.classes?.length) {
+            newEdgeInfo.classList.add(...edgeInfoMetadata.classes);
+        }
         this.edgeInfosSection?.appendChild(newEdgeInfo);
 
         return newEdgeInfo;

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -2297,7 +2297,8 @@ export class NetworkAreaDiagramViewer {
             }
         }
         this.updateEdgeInfoMetadata(edgeInfoMetadata, value, preserveExistingDirection);
-        const edgeInfo = this.getOrCreateEdgeInfo(edge, edgeInfoMetadata);
+        const classes = (side == '1' ? edge.classes1 : edge.classes2) ?? [];
+        const edgeInfo = this.getOrCreateEdgeInfo(edgeInfoMetadata, classes);
         if (!halfEdge.edgeInfoId) {
             halfEdge.edgeInfoId = edgeInfo.id;
         }
@@ -2401,7 +2402,9 @@ export class NetworkAreaDiagramViewer {
             edge.edgeInfoMiddle = edgeInfoMetadata;
         }
 
-        const edgeInfo = this.getOrCreateEdgeInfo(edge, edgeInfoMetadata);
+        // the middle edge info belongs to both sides, so it carries the union of their classes
+        const classes = [...new Set([...(edge.classes1 ?? []), ...(edge.classes2 ?? [])])];
+        const edgeInfo = this.getOrCreateEdgeInfo(edgeInfoMetadata, classes);
 
         // componentType replaces the arrow, so it follows the same showArrow threshold
         if (showArrow) {
@@ -2472,7 +2475,7 @@ export class NetworkAreaDiagramViewer {
         branchLabelElement.innerHTML = formattedValue;
     }
 
-    private getOrCreateEdgeInfo(edgeMetadata: EdgeMetadata, edgeInfoMetadata: EdgeInfoMetadata): SVGElement {
+    private getOrCreateEdgeInfo(edgeInfoMetadata: EdgeInfoMetadata, classes: string[]): SVGElement {
         const edgeInfo = this.getEdgeInfo(edgeInfoMetadata.svgId);
         if (edgeInfo) {
             return edgeInfo;
@@ -2480,8 +2483,8 @@ export class NetworkAreaDiagramViewer {
 
         const newEdgeInfo = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         newEdgeInfo.id = edgeInfoMetadata.svgId;
-        if (edgeMetadata.classes1?.length || edgeMetadata.classes2?.length) {
-            newEdgeInfo.classList.add(...new Set([...(edgeMetadata.classes1 ?? []), ...(edgeMetadata.classes2 ?? [])]));
+        if (classes.length) {
+            newEdgeInfo.classList.add(...classes);
         }
         this.edgeInfosSection?.appendChild(newEdgeInfo);
 

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -379,9 +379,6 @@ export class NetworkAreaDiagramViewer {
         this.textEdgesSection = this.getOrCreateTextEdgesSection();
         this.edgeInfosSection = this.getOrCreateEdgeInfosSection();
 
-        // Tag the server-rendered edge infos with their side's voltage-level class
-        this.addClassesToEdgeInfos();
-
         // add events
         const hasMetadata = this.diagramMetadata !== null;
         if (this.hasNodeInteraction() && hasMetadata) {
@@ -1914,25 +1911,6 @@ export class NetworkAreaDiagramViewer {
         return <SVGElement>this.edgeInfosSection?.querySelector(":scope > [id='" + edgeInfoSvgId + "']") ?? null;
     }
 
-    // Apply the edge info metadata classes (e.g. its side's voltage-level class) on the matching SVG element
-    private addClassesToEdgeInfos(): void {
-        this.diagramMetadata?.edges.forEach((edge) => {
-            this.addClassesToEdgeInfo(edge.edgeInfo1);
-            this.addClassesToEdgeInfo(edge.edgeInfo2);
-            this.addClassesToEdgeInfo(edge.edgeInfoMiddle);
-        });
-        this.diagramMetadata?.injections?.forEach((injection) => {
-            this.addClassesToEdgeInfo(injection.edgeInfo);
-        });
-    }
-
-    private addClassesToEdgeInfo(edgeInfoMetadata: EdgeInfoMetadata | undefined): void {
-        if (!edgeInfoMetadata?.classes?.length) {
-            return;
-        }
-        this.getEdgeInfo(edgeInfoMetadata.svgId)?.classList.add(...edgeInfoMetadata.classes);
-    }
-
     private hasTextNode(textNode: TextNodeMetadata) {
         return !!this.textNodesSection?.querySelector(":scope > [id='" + textNode.svgId + "']");
     }
@@ -2319,7 +2297,7 @@ export class NetworkAreaDiagramViewer {
             }
         }
         this.updateEdgeInfoMetadata(edgeInfoMetadata, value, preserveExistingDirection);
-        const edgeInfo = this.getOrCreateEdgeInfo(edgeInfoMetadata);
+        const edgeInfo = this.getOrCreateEdgeInfo(edge, edgeInfoMetadata);
         if (!halfEdge.edgeInfoId) {
             halfEdge.edgeInfoId = edgeInfo.id;
         }
@@ -2423,7 +2401,7 @@ export class NetworkAreaDiagramViewer {
             edge.edgeInfoMiddle = edgeInfoMetadata;
         }
 
-        const edgeInfo = this.getOrCreateEdgeInfo(edgeInfoMetadata);
+        const edgeInfo = this.getOrCreateEdgeInfo(edge, edgeInfoMetadata);
 
         // componentType replaces the arrow, so it follows the same showArrow threshold
         if (showArrow) {
@@ -2494,7 +2472,7 @@ export class NetworkAreaDiagramViewer {
         branchLabelElement.innerHTML = formattedValue;
     }
 
-    private getOrCreateEdgeInfo(edgeInfoMetadata: EdgeInfoMetadata): SVGElement {
+    private getOrCreateEdgeInfo(edgeMetadata: EdgeMetadata, edgeInfoMetadata: EdgeInfoMetadata): SVGElement {
         const edgeInfo = this.getEdgeInfo(edgeInfoMetadata.svgId);
         if (edgeInfo) {
             return edgeInfo;
@@ -2502,8 +2480,8 @@ export class NetworkAreaDiagramViewer {
 
         const newEdgeInfo = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         newEdgeInfo.id = edgeInfoMetadata.svgId;
-        if (edgeInfoMetadata.classes?.length) {
-            newEdgeInfo.classList.add(...edgeInfoMetadata.classes);
+        if (edgeMetadata.classes1?.length || edgeMetadata.classes2?.length) {
+            newEdgeInfo.classList.add(...new Set([...(edgeMetadata.classes1 ?? []), ...(edgeMetadata.classes2 ?? [])]));
         }
         this.edgeInfosSection?.appendChild(newEdgeInfo);
 

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -2502,8 +2502,6 @@ export class NetworkAreaDiagramViewer {
 
         const newEdgeInfo = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         newEdgeInfo.id = edgeInfoMetadata.svgId;
-        // Re-apply the side's voltage-level class(es) when the edge info is recreated (e.g. adaptive
-        // zoom), so it stays hidden consistently with its voltage level.
         if (edgeInfoMetadata.classes?.length) {
             newEdgeInfo.classList.add(...edgeInfoMetadata.classes);
         }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -2412,8 +2412,8 @@ export class NetworkAreaDiagramViewer {
             edge.edgeInfoMiddle = edgeInfoMetadata;
         }
 
-        // the middle edge info belongs to both sides, so it carries the union of their classes
-        const classes = [...new Set([...(edge.classes1 ?? []), ...(edge.classes2 ?? [])])];
+        // the middle edge info belongs to both sides, so it carries the classes of both
+        const classes = [...(edge.classes1 ?? []), ...(edge.classes2 ?? [])];
         const edgeInfo = this.getOrCreateEdgeInfo(edgeInfoMetadata, classes);
 
         // componentType replaces the arrow, so it follows the same showArrow threshold


### PR DESCRIPTION
## Context

Edge infos (arrows and value labels) live in a flat `nad-edge-infos` group and, unlike voltage level nodes and their labels, do not carry the voltage-level CSS class of the side they belong to. As a result, CSS rules that hide a voltage level (voltage-level filtering, zoom-based hiding) leave these arrows and labels visible.

## Change

The voltage-level class(es) are carried by the edge metadata (computed server-side in powsybl-diagram via `classes1`/`classes2`), so they are applied directly on the edge info SVG element :

- Each side edge info is tagged with only its own side's classes (`classes1` for side 1, `classes2` for side 2); the middle edge info, which belongs to both sides, carries the union of both.
- The class list is built by the caller and passed to `getOrCreateEdgeInfo`, covering both the initial server-rendered infos and those recreated during adaptive zoom.
