### PR TITLE
Fix nad-viewer: reset Panzoom at text selection

### DIFF
--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -903,7 +903,14 @@ export class NetworkAreaDiagramViewer {
         } else if (this.straightenedElement) {
             // straightening line
             this.onStraightenEnd();
+            this.enablePanzoom();
+        } else if (this.draggedElement) {
+            // this.draggedElement could be defined here even if this.isDragging
+            // is false in case of text selection. then we must re enable pan zoom.
+            this.enablePanzoom();
         }
+        // It's tempting to want to factor by calling 'enablePanzoom' here,
+        // however it's a bad idea and breaks the functionality of the pan!
         this.resetMouseEventParams();
     }
 
@@ -3029,7 +3036,6 @@ export class NetworkAreaDiagramViewer {
         this.callBendLineCallback(this.straightenedElement, LineOperation.STRAIGHTEN);
         // reset data
         this.straightenedElement = null;
-        this.enablePanzoom();
     }
 
     private callBendLineCallback(linePointElement: SVGGraphicsElement, lineOperation: LineOperation) {


### PR DESCRIPTION
Manage a border case to reset Panzoom at text selection in Edge Browser

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix



**What is the current behavior?**
<!-- You can also link to an open issue here -->
<img width="1016" height="1268" alt="BugPanImpossibleAfterTextSelection" src="https://github.com/user-attachments/assets/6d2d2775-860d-43a8-898a-eda189cce5b6" />
With Edge, selecting text in the viewer (double click) works correctly, but then it seems impossible to pan zoom in the SVG.
Not linked with this specific browser, but the problem appears more clearly with its text selection mini-menu.
After text selection it's impossible to pan and zoom is messy. See in the linked animation GIF that trying to pan and it reopen the text selection mini-menu multiple times. At the end doing one step of zoom just over zoom out.
You could recover the pan zoon by clicking on a node for examole

**What is the new behavior (if this is a feature change)?**
Pan/zoom is ok after text selection now


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
