### PR TITLE
nad-viewer: Drop nad-edge-infos from the SVG in `adaptiveTextZoom` mode at init

### DIFF
--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -382,7 +382,7 @@ export class NetworkAreaDiagramViewer {
         if (this.nadViewerParameters.getAdaptiveTextZoom().enabled) {
             this.edgeInfosSection = this.createEmptyEdgeInfosSection();
             console.warn(
-                'AdaptiveTextZoom mode : nad-edge-infos has been dropped from the SVG, it will be recreated from metadata'
+                'AdaptiveTextZoom mode activated: creating nad-edge-infos from metadata and ignoring it from the SVG'
             );
         } else {
             this.edgeInfosSection = this.getOrCreateEdgeInfosSection();

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -377,7 +377,16 @@ export class NetworkAreaDiagramViewer {
 
         this.textNodesSection = this.getOrCreateTextNodesSection();
         this.textEdgesSection = this.getOrCreateTextEdgesSection();
-        this.edgeInfosSection = this.getOrCreateEdgeInfosSection();
+        // Do not get nad-edge-infos from the SVG in the following modes
+        // IT will be build later in the updateAdaptiveEdgeInfos at init
+        if (this.nadViewerParameters.getAdaptiveTextZoom().enabled) {
+            this.edgeInfosSection = this.createEmptyEdgeInfosSection();
+            console.warn(
+                'AdaptiveTextZoom mode : nad-edge-infos has been dropped from the SVG, it will be recreated from metadata'
+            );
+        } else {
+            this.edgeInfosSection = this.getOrCreateEdgeInfosSection();
+        }
 
         // add events
         const hasMetadata = this.diagramMetadata !== null;
@@ -502,12 +511,17 @@ export class NetworkAreaDiagramViewer {
         return legendEdgesSection;
     }
 
+    private createEmptyEdgeInfosSection(): SVGElement {
+        const edgeInfos = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        edgeInfos.classList.add('nad-edge-infos');
+        this.innerSvg?.appendChild(edgeInfos);
+        return edgeInfos;
+    }
+
     private getOrCreateEdgeInfosSection(): SVGElement {
-        let edgeInfos = <SVGElement>this.innerSvg?.querySelector(':scope > g.nad-edge-infos');
+        const edgeInfos = <SVGElement>this.innerSvg?.querySelector(':scope > g.nad-edge-infos');
         if (!edgeInfos) {
-            edgeInfos = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-            edgeInfos.classList.add('nad-edge-infos');
-            this.innerSvg?.appendChild(edgeInfos);
+            return this.createEmptyEdgeInfosSection();
         }
         return edgeInfos;
     }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -377,13 +377,18 @@ export class NetworkAreaDiagramViewer {
 
         this.textNodesSection = this.getOrCreateTextNodesSection();
         this.textEdgesSection = this.getOrCreateTextEdgesSection();
-        // Do not get nad-edge-infos from the SVG in the following modes
-        // IT will be build later in the updateAdaptiveEdgeInfos at init
+        // Ignore nad-edge-infos from the SVG in the AdaptiveTextZoom mode at init
+        // It will be fullfilled later in the updateAdaptiveEdgeInfos
         if (this.nadViewerParameters.getAdaptiveTextZoom().enabled) {
+            // if the nad-edge-infos section exists in the SVG, replace it by an empty one
+            const existingEdgeInfos = <SVGElement>this.innerSvg?.querySelector(':scope > g.nad-edge-infos');
+            if (existingEdgeInfos) {
+                existingEdgeInfos.remove();
+                console.warn(
+                    'AdaptiveTextZoom mode activated: creating nad-edge-infos from metadata and ignoring it from the SVG'
+                );
+            }
             this.edgeInfosSection = this.createEmptyEdgeInfosSection();
-            console.warn(
-                'AdaptiveTextZoom mode activated: creating nad-edge-infos from metadata and ignoring it from the SVG'
-            );
         } else {
             this.edgeInfosSection = this.getOrCreateEdgeInfosSection();
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
If we use a SVG file containing `nad-edge-infos` at initialisation with the `adaptiveTextZoom` mode then edgeInfos aren't written from metadata nor updated from it (no classes added etc...).
Note: This is not the common case, but could happen in the demo app for example

**What is the new behavior (if this is a feature change)?**
Drop nad-edge-infos from the SVG in adaptiveTextZoom mode it will be created from metadata even at init.
Add a console warning if this kind of svg file is used with this mode

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
