### PR TITLE
[nad-viewer] Add SVG injections to NAD creation from metadata

### DIFF
--- a/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-metadata.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-metadata.ts
@@ -149,6 +149,8 @@ export interface InjectionMetadata {
     busNodeId: string;
     vlNodeId: string;
     edgeInfo?: EdgeInfoMetadata;
+    classes?: string[];
+    style?: string;
 }
 
 export interface EdgeInfoMetadata {

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-utils.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-utils.ts
@@ -406,6 +406,7 @@ export function getLabelShiftAndStyle(
 }
 
 // get the label data: angle and [shift, style] of a external and internal label
+// input angle is in radians, output angle, in LabelData, is in degrees
 export function getLabelData(angle: number, arrowLabelShift: number): LabelData {
     const textFlipped = Math.cos(angle) < 0;
     const internalShiftAndStyle = getLabelShiftAndStyle(angle, false, arrowLabelShift);

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-utils.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-utils.ts
@@ -7,7 +7,7 @@
 
 import { Point } from '@svgdotjs/svg.js';
 import { EdgeInfoEnum, SvgParameters } from './svg-parameters';
-import { EdgeType, NodeRadius } from './diagram-types';
+import { EdgeType, LabelData, NodeRadius } from './diagram-types';
 
 export function getDistance(point1: Point, point2: Point): number {
     const deltax = point1.x - point2.x;
@@ -403,4 +403,16 @@ export function getLabelShiftAndStyle(
     const style: string | undefined = externalLabel == textFlipped ? 'text-anchor:end' : undefined;
     const shift: number = arrowLabelShift * (externalLabel ? 1 : -1);
     return [textFlipped ? -shift : shift, style];
+}
+
+// get the label data: angle and [shift, style] of a external and internal label
+export function getLabelData(angle: number, arrowLabelShift: number): LabelData {
+    const textFlipped = Math.cos(angle) < 0;
+    const internalShiftAndStyle = getLabelShiftAndStyle(angle, false, arrowLabelShift);
+    const externalShiftAndStyle = getLabelShiftAndStyle(angle, true, arrowLabelShift);
+    return {
+        angle: radToDeg(textFlipped ? angle - Math.PI : angle),
+        internal: { shift: internalShiftAndStyle[0], style: internalShiftAndStyle[1] },
+        external: { shift: externalShiftAndStyle[0], style: externalShiftAndStyle[1] },
+    };
 }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/edge-router.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/edge-router.ts
@@ -7,12 +7,12 @@
  */
 
 import { Point } from '@svgdotjs/svg.js';
-import { DiagramMetadata, EdgeMetadata, NodeMetadata } from './diagram-metadata';
+import { BusNodeMetadata, DiagramMetadata, EdgeMetadata, InjectionMetadata, NodeMetadata } from './diagram-metadata';
 import { SvgParameters } from './svg-parameters';
 import * as DiagramUtils from './diagram-utils';
 import * as MetadataUtils from './metadata-utils';
 import * as HalfEdgeUtils from './half-edge-utils';
-import { HalfEdge, LabelData } from './diagram-types';
+import { HalfEdge, LabelData, NodeRadius } from './diagram-types';
 
 export class EdgeRouter {
     diagramMetadata: DiagramMetadata;
@@ -23,6 +23,8 @@ export class EdgeRouter {
     edgeMiddleData: Record<string, [Point, number]> = {};
     edgeMiddleLabelData: Record<string, LabelData> = {};
     threeWTEdgePoints: Record<string, [Point, Point]> = {};
+    injectionData: Record<string, [Point, Point, Point, number]> = {};
+    injectionLabelData: Record<string, LabelData> = {};
     nodeAngles: Record<string, number[]> = {};
 
     constructor(diagramMetadata: DiagramMetadata) {
@@ -96,11 +98,40 @@ export class EdgeRouter {
         return this.threeWTEdgePoints[edgeId];
     }
 
+    public getInjectionEdgePoints(injectionId: string): Point[] | undefined {
+        const injData = this.injectionData[injectionId];
+        if (!injData) {
+            return undefined;
+        }
+        return [injData[0], injData[1]];
+    }
+
+    public getInjectionInfoPoint(injectionId: string): Point | undefined {
+        const injData = this.injectionData[injectionId];
+        if (!injData) {
+            return undefined;
+        }
+        return injData[2];
+    }
+
+    public getInjectionInfoAngle(injectionId: string): number | undefined {
+        const injData = this.injectionData[injectionId];
+        if (!injData) {
+            return undefined;
+        }
+        return injData[3];
+    }
+
+    public getInjectoinLabelData(injectionId: string): LabelData | undefined {
+        return this.injectionLabelData[injectionId];
+    }
+
     private init() {
         const edgeGroups = this.groupEdges();
         this.storeGroupedEdges(edgeGroups.groupedEdges);
         this.storeLoopEdges(edgeGroups.loopEdges);
         this.storeThreeWtEdges(edgeGroups.threeWtEdges);
+        this.storeInjections();
     }
 
     private groupEdges(): {
@@ -241,7 +272,8 @@ export class EdgeRouter {
             const loopEdges = edges[edgeId];
             const availableAngles = this.findAvailableAngles(
                 this.nodeAngles[loopEdges[0].node1] ?? [],
-                loopEdges.length
+                loopEdges.length,
+                this.svgParameters.getLoopEdgesAperture() * 1.2
             );
             loopEdges.forEach((loopEdge, index) => {
                 const angle = availableAngles[index];
@@ -250,9 +282,8 @@ export class EdgeRouter {
         }
     }
 
-    private findAvailableAngles(anglesOtherEdges: number[], nbAngles: number): number[] {
+    private findAvailableAngles(anglesOtherEdges: number[], nbAngles: number, slotAperture: number): number[] {
         let availableAngles: number[] = [];
-        const slotAperture = this.svgParameters.getLoopEdgesAperture() * 1.2;
         if (anglesOtherEdges.length == 0) {
             Array.from(new Array(nbAngles).keys())
                 .map((index) => (index * 2 * Math.PI) / nbAngles)
@@ -446,5 +477,66 @@ export class EdgeRouter {
         const anchorAngle = leadingAngle + (index * 2 * Math.PI) / 3;
         const threeWtAnchor: Point = DiagramUtils.shiftRhoTheta(pointTwt, dNodeToAnchor, anchorAngle);
         this.threeWTEdgePoints[edge.svgId] = [edgeStart, threeWtAnchor];
+    }
+
+    private storeInjections() {
+        // group injections by node
+        const nodesInjections: Record<string, InjectionMetadata[]> = {};
+        this.diagramMetadata.injections?.forEach((injection) => {
+            const nodeInjections: InjectionMetadata[] = nodesInjections[injection.vlNodeId] ?? [];
+            nodeInjections.push(injection);
+            nodesInjections[injection.vlNodeId] = nodeInjections;
+        });
+        // store injections
+        for (const nodeId in nodesInjections) {
+            const nodeInjections = nodesInjections[nodeId];
+            const availableAngles = this.findAvailableAngles(
+                this.nodeAngles[nodeId] ?? [],
+                nodeInjections.length,
+                this.svgParameters.getInjectionAperture()
+            );
+            const vlNode = MetadataUtils.getNodeMetadata(nodeId, this.diagramMetadata);
+            const vlPoint = new Point(vlNode?.x ?? 0, vlNode?.y ?? 0);
+            const busNodes = MetadataUtils.getBusNodesMetadata(nodeId, this.diagramMetadata.busNodes);
+            busNodes.forEach((busNode) => {
+                const nodeRadius = MetadataUtils.getNodeRadius(busNode, vlNode, this.svgParameters);
+                nodeInjections.forEach((injection, index) => {
+                    this.storeInjectionData(injection.svgId, vlPoint, busNode, nodeRadius, availableAngles, index);
+                });
+            });
+        }
+    }
+
+    private storeInjectionData(
+        injectionId: string,
+        vlPoint: Point,
+        busNode: BusNodeMetadata,
+        nodeRadius: NodeRadius,
+        availableAngles: number[],
+        index: number
+    ) {
+        const angle = availableAngles[index];
+        const injPoint: Point = DiagramUtils.getPointAtDistanceWithAngle(
+            vlPoint,
+            this.svgParameters.getInjectionEdgeLength(),
+            angle
+        );
+        const busNodePoint = DiagramUtils.getEdgeStart(
+            busNode.svgId,
+            vlPoint,
+            injPoint,
+            nodeRadius.busOuterRadius,
+            this.svgParameters.getUnknownBusNodeExtraRadius()
+        );
+        const arrowShift =
+            this.svgParameters.getArrowShift() + (nodeRadius.voltageLevelRadius - nodeRadius.busOuterRadius);
+        const arrowCenter = DiagramUtils.getPointAtDistance(busNodePoint, injPoint, arrowShift);
+        const rotationAngle = DiagramUtils.radToDeg(angle + (angle > Math.PI / 2 ? (-3 * Math.PI) / 2 : Math.PI / 2));
+        this.injectionData[injectionId] = [busNodePoint, injPoint, arrowCenter, rotationAngle];
+
+        this.injectionLabelData[injectionId] = DiagramUtils.getLabelData(
+            angle,
+            this.svgParameters.getArrowLabelShift()
+        );
     }
 }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/edge-router.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/edge-router.ts
@@ -15,6 +15,8 @@ import * as HalfEdgeUtils from './half-edge-utils';
 import { HalfEdge, LabelData, NodeRadius } from './diagram-types';
 
 export class EdgeRouter {
+    static readonly LOOP_EDGES_SLOT_APERTURE_SCALING = 1.2;
+
     diagramMetadata: DiagramMetadata;
     svgParameters: SvgParameters;
     edgePoints: Record<string, [Point[], Point[]]> = {};
@@ -122,7 +124,7 @@ export class EdgeRouter {
         return injData[3];
     }
 
-    public getInjectoinLabelData(injectionId: string): LabelData | undefined {
+    public getInjectionLabelData(injectionId: string): LabelData | undefined {
         return this.injectionLabelData[injectionId];
     }
 
@@ -234,8 +236,8 @@ export class EdgeRouter {
             ],
         ];
         this.edgeSideLabelData[edgeId] = [
-            HalfEdgeUtils.getLabelData(halfEdges[0], this.svgParameters.getArrowLabelShift()),
-            HalfEdgeUtils.getLabelData(halfEdges[1], this.svgParameters.getArrowLabelShift()),
+            HalfEdgeUtils.getHalfEdgeLabelData(halfEdges[0], this.svgParameters.getArrowLabelShift()),
+            HalfEdgeUtils.getHalfEdgeLabelData(halfEdges[1], this.svgParameters.getArrowLabelShift()),
         ];
     }
 
@@ -273,7 +275,7 @@ export class EdgeRouter {
             const availableAngles = this.findAvailableAngles(
                 this.nodeAngles[loopEdges[0].node1] ?? [],
                 loopEdges.length,
-                this.svgParameters.getLoopEdgesAperture() * 1.2
+                this.svgParameters.getLoopEdgesAperture() * EdgeRouter.LOOP_EDGES_SLOT_APERTURE_SCALING
             );
             loopEdges.forEach((loopEdge, index) => {
                 const angle = availableAngles[index];
@@ -481,15 +483,15 @@ export class EdgeRouter {
 
     private storeInjections() {
         // group injections by node
-        const nodesInjections: Record<string, InjectionMetadata[]> = {};
+        const injectionsByNode: Record<string, InjectionMetadata[]> = {};
         this.diagramMetadata.injections?.forEach((injection) => {
-            const nodeInjections: InjectionMetadata[] = nodesInjections[injection.vlNodeId] ?? [];
+            const nodeInjections: InjectionMetadata[] = injectionsByNode[injection.vlNodeId] ?? [];
             nodeInjections.push(injection);
-            nodesInjections[injection.vlNodeId] = nodeInjections;
+            injectionsByNode[injection.vlNodeId] = nodeInjections;
         });
         // store injections
-        for (const nodeId in nodesInjections) {
-            const nodeInjections = nodesInjections[nodeId];
+        for (const nodeId in injectionsByNode) {
+            const nodeInjections = injectionsByNode[nodeId];
             const availableAngles = this.findAvailableAngles(
                 this.nodeAngles[nodeId] ?? [],
                 nodeInjections.length,
@@ -530,7 +532,9 @@ export class EdgeRouter {
         );
         const arrowShift =
             this.svgParameters.getArrowShift() + (nodeRadius.voltageLevelRadius - nodeRadius.busOuterRadius);
+        // point of the arrow added to the injection edge info
         const arrowCenter = DiagramUtils.getPointAtDistance(busNodePoint, injPoint, arrowShift);
+        // rotation of the arrow added to the injection edge info
         const rotationAngle = DiagramUtils.radToDeg(angle + (angle > Math.PI / 2 ? (-3 * Math.PI) / 2 : Math.PI / 2));
         this.injectionData[injectionId] = [busNodePoint, injPoint, arrowCenter, rotationAngle];
 

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/half-edge-utils.test.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/half-edge-utils.test.ts
@@ -52,7 +52,7 @@ test('getArrowRotation', () => {
     expect(HalfEdgeUtils.getArrowRotation(halfEdge4)).toBe(-45);
 });
 
-test('getLabelData', () => {
+test('getHalfEdgeLabelData', () => {
     const halfEdge1: HalfEdge = {
         side: '1',
         fork: false,
@@ -60,7 +60,7 @@ test('getLabelData', () => {
         voltageLevelRadius: 0,
         edgePoints: [new Point(10, 10), new Point(50, 50)],
     };
-    const labelData = HalfEdgeUtils.getLabelData(halfEdge1, 19);
+    const labelData = HalfEdgeUtils.getHalfEdgeLabelData(halfEdge1, 19);
     expect(labelData.angle).toBe(45);
     expect(labelData.external.shift).toBe(19);
     expect(labelData.external.style).toBe(undefined);
@@ -74,7 +74,7 @@ test('getLabelData', () => {
         voltageLevelRadius: 0,
         edgePoints: [new Point(0, 0), new Point(10, 10), new Point(-30, 50)],
     };
-    const flippedLabelData = HalfEdgeUtils.getLabelData(halfEdge2, 19);
+    const flippedLabelData = HalfEdgeUtils.getHalfEdgeLabelData(halfEdge2, 19);
     expect(flippedLabelData.angle).toBe(-45);
     expect(flippedLabelData.external.shift).toBe(-19);
     expect(flippedLabelData.external.style).toBe('text-anchor:end');

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/half-edge-utils.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/half-edge-utils.ts
@@ -16,7 +16,7 @@ import {
     getEdgeNameAngle,
     getEdgeStart,
     getFormattedPolyline,
-    getLabelData as getLabelInfo,
+    getLabelData,
     getLabelShiftAndStyle,
     getMidPosition,
     getPointAtDistance,
@@ -76,9 +76,9 @@ export function getInfoPoint(halfEdge: HalfEdge, svgParameters: SvgParameters): 
 }
 
 // get the label data: angle and [shift, style] of a external and internal label
-export function getLabelData(halfEdge: HalfEdge, arrowLabelShift: number): LabelData {
+export function getHalfEdgeLabelData(halfEdge: HalfEdge, arrowLabelShift: number): LabelData {
     const angle = getArrowEdgeAngle(halfEdge);
-    return getLabelInfo(angle, arrowLabelShift);
+    return getLabelData(angle, arrowLabelShift);
 }
 
 // get the polyline of a converter station of an HVDC line edge

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/half-edge-utils.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/half-edge-utils.ts
@@ -16,6 +16,7 @@ import {
     getEdgeNameAngle,
     getEdgeStart,
     getFormattedPolyline,
+    getLabelData as getLabelInfo,
     getLabelShiftAndStyle,
     getMidPosition,
     getPointAtDistance,
@@ -77,14 +78,7 @@ export function getInfoPoint(halfEdge: HalfEdge, svgParameters: SvgParameters): 
 // get the label data: angle and [shift, style] of a external and internal label
 export function getLabelData(halfEdge: HalfEdge, arrowLabelShift: number): LabelData {
     const angle = getArrowEdgeAngle(halfEdge);
-    const textFlipped = Math.cos(angle) < 0;
-    const internalShiftAndStyle = getLabelShiftAndStyle(angle, false, arrowLabelShift);
-    const externalShiftAndStyle = getLabelShiftAndStyle(angle, true, arrowLabelShift);
-    return {
-        angle: radToDeg(textFlipped ? angle - Math.PI : angle),
-        internal: { shift: internalShiftAndStyle[0], style: internalShiftAndStyle[1] },
-        external: { shift: externalShiftAndStyle[0], style: externalShiftAndStyle[1] },
-    };
+    return getLabelInfo(angle, arrowLabelShift);
 }
 
 // get the polyline of a converter station of an HVDC line edge

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/metadata-utils.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/metadata-utils.ts
@@ -11,6 +11,7 @@ import {
     BusNodeMetadata,
     DiagramMetadata,
     EdgeMetadata,
+    InjectionMetadata,
     NodeMetadata,
     PointMetadata,
     TextNodeMetadata,
@@ -410,4 +411,12 @@ export function isBoundaryNode(node: NodeMetadata): boolean {
 // get the type of a node
 export function getNodeType(node: NodeMetadata): NodeType {
     return node.type === undefined ? NodeType.UNKNOWN : (NodeTypeMapping[node.type] ?? NodeType.UNKNOWN);
+}
+
+export function getInjectionMetadata(
+    nodeId: string,
+    busNodeId: string,
+    injections: InjectionMetadata[]
+): InjectionMetadata[] {
+    return injections.filter((edge) => edge.vlNodeId == nodeId && edge.busNodeId == busNodeId);
 }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -1372,7 +1372,7 @@ export class NetworkAreaDiagramViewer {
         const arrowsNum = this.redrawArrows(edgeInfo, HalfEdgeUtils.getArrowRotation(halfEdge));
 
         // move edge labels
-        const labelData = HalfEdgeUtils.getLabelData(halfEdge, this.svgParameters.getArrowLabelShift());
+        const labelData = HalfEdgeUtils.getHalfEdgeLabelData(halfEdge, this.svgParameters.getArrowLabelShift());
         const factor: number = arrowsNum == 2 ? this.svgParameters.getDoubleArrowShiftFactorText() : 1;
         // move edge labelB
         const labelBElement = edgeInfo.querySelector('text:nth-of-type(1)') as SVGGraphicsElement;

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-parameters.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-parameters.ts
@@ -73,6 +73,9 @@ export class SvgParameters {
     static readonly LOOP_EDGE_APERTURE_DEFAULT = 60;
     static readonly LOOP_DISTANCE_DEFAULT = 120;
     static readonly LOOP_CONTROL_DISTANCE_DEFAULT = 40;
+    static readonly INJECTION_EDGE_LENGTH_DEFAULT = 145;
+    static readonly INJECTION_APERTURE_DEFAULT = 10;
+    static readonly INJECTION_CIRCLE_RADIUS_DEFAULT = 25;
 
     svgParametersMetadata: SvgParametersMetadata | undefined;
 
@@ -202,5 +205,17 @@ export class SvgParameters {
 
     public getLoopControlDistance(): number {
         return this.svgParametersMetadata?.loopControlDistance ?? SvgParameters.LOOP_CONTROL_DISTANCE_DEFAULT;
+    }
+
+    public getInjectionEdgeLength(): number {
+        return this.svgParametersMetadata?.injectionEdgeLength ?? SvgParameters.INJECTION_EDGE_LENGTH_DEFAULT;
+    }
+
+    public getInjectionAperture(): number {
+        return this.svgParametersMetadata?.injectionAperture ?? SvgParameters.INJECTION_APERTURE_DEFAULT;
+    }
+
+    public getInjectionCircleRadius(): number {
+        return this.svgParametersMetadata?.injectionCircleRadius ?? SvgParameters.INJECTION_CIRCLE_RADIUS_DEFAULT;
     }
 }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
@@ -26,6 +26,7 @@ import DefaultLibraryComponents from '../resources/default-library/components.js
 import * as ComponentUtils from './component-utils';
 
 export class SvgWriter {
+    static readonly SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
     static readonly NODES_CLASS = 'nad-vl-nodes';
     static readonly BUS_CLASS = 'nad-busnode';
     static readonly EDGES_CLASS = 'nad-branch-edges';
@@ -139,7 +140,7 @@ export class SvgWriter {
     }
 
     private getSvgRootElement(textBoxSize?: { width: number; height: number }): SVGSVGElement {
-        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        const svg = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'svg');
         const viewBox = MetadataUtils.getViewBox(
             this.diagramMetadata.nodes,
             this.diagramMetadata.textNodes,
@@ -152,10 +153,10 @@ export class SvgWriter {
 
     private getNodesAndInjectionsAndInfos(): { nodes: SVGGElement; injections: SVGGElement; infos: SVGGElement[] } {
         // create g nodes element
-        const gNodesElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gNodesElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gNodesElement.classList.add(SvgWriter.NODES_CLASS);
         // create g injections element
-        const gInjectionsElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gInjectionsElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gInjectionsElement.classList.add(SvgWriter.INJECTIONS_CLASS);
         // create injection infos elements list
         let injectionsInfos: SVGGElement[] = [];
@@ -183,7 +184,7 @@ export class SvgWriter {
         infos: SVGGElement[];
     } {
         // create node
-        const gNodeElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gNodeElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gNodeElement.id = node.svgId;
         if (MetadataUtils.isBoundaryNode(node)) {
             gNodeElement.classList.add(SvgWriter.BOUNDARY_BUS_CLASS);
@@ -194,13 +195,13 @@ export class SvgWriter {
             'translate(' + DiagramUtils.getFormattedPoint(new Point(node.x, node.y)) + ')'
         );
         // create injection
-        const gInjectionNodeElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gInjectionNodeElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         SvgUtils.addCssClasses(gInjectionNodeElement, node.classes);
         // create injection infos elements list
         const injectionsInfos: SVGGElement[] = [];
         // add buses
         if (node.unknownBus) {
-            const circleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            const circleElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'circle');
             circleElement.classList.add(SvgWriter.UNKNOWN_BUS_CLASS);
             circleElement.setAttribute(
                 'r',
@@ -234,7 +235,7 @@ export class SvgWriter {
     private getBusNode(busNode: BusNodeMetadata, node: NodeMetadata, traversingBusEdgesAngles: number[]): SVGElement {
         const nodeRadius = MetadataUtils.getNodeRadius(busNode, node, this.svgParameters);
         if (MetadataUtils.isBoundaryNode(node)) {
-            const pathElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            const pathElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'path');
             pathElement.id = busNode.svgId;
             SvgUtils.addCssClasses(pathElement, busNode.classes, SvgWriter.BUS_CLASS);
             SvgUtils.addElementStyle(pathElement, busNode.style);
@@ -246,14 +247,14 @@ export class SvgWriter {
             pathElement.setAttribute('d', path);
             return pathElement;
         } else if (busNode.index == 0) {
-            const circleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            const circleElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'circle');
             circleElement.id = busNode.svgId;
             SvgUtils.addCssClasses(circleElement, busNode.classes, SvgWriter.BUS_CLASS);
             SvgUtils.addElementStyle(circleElement, busNode.style);
             circleElement.setAttribute('r', DiagramUtils.getFormattedValue(nodeRadius.busOuterRadius));
             return circleElement;
         } else {
-            const pathElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            const pathElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'path');
             pathElement.id = busNode.svgId;
             SvgUtils.addCssClasses(pathElement, busNode.classes, SvgWriter.BUS_CLASS);
             SvgUtils.addElementStyle(pathElement, busNode.style);
@@ -297,12 +298,12 @@ export class SvgWriter {
         busNode: BusNodeMetadata,
         injectionsInfos: SVGGElement[]
     ) {
-        const gInjectionBusElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gInjectionBusElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         SvgUtils.addCssClasses(gInjectionBusElement, busNode.classes);
         gInjectionNodeElement.appendChild(gInjectionBusElement);
 
         injections.forEach((injection) => {
-            const gInjectionElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+            const gInjectionElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
             gInjectionElement.id = injection.svgId;
             SvgUtils.addCssClasses(gInjectionElement, injection.classes);
             SvgUtils.addElementStyle(gInjectionElement, injection.style);
@@ -320,16 +321,16 @@ export class SvgWriter {
     }
 
     private getInjectionEdge(points: Point[]): SVGPolylineElement {
-        const polylineInjectionEdgeElement = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+        const polylineInjectionEdgeElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'polyline');
         polylineInjectionEdgeElement.classList.add(SvgWriter.EDGE_CLASS);
         polylineInjectionEdgeElement.setAttribute('points', DiagramUtils.getFormattedPolyline(points));
         return polylineInjectionEdgeElement;
     }
 
     private getInjectionIcon(points: Point[], componentType: string): SVGGElement {
-        const gInjectionIconElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gInjectionIconElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
 
-        const injectionCircleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        const injectionCircleElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'circle');
         const circleCenter = DiagramUtils.getPointAtDistance(
             points[1],
             points[0],
@@ -351,16 +352,16 @@ export class SvgWriter {
     private getInjectionInfo(injectionId: string, info: EdgeInfoMetadata): SVGGElement {
         const infoPoint = this.edgeRouter?.getInjectionInfoPoint(injectionId);
         const infoAngle = this.edgeRouter?.getInjectionInfoAngle(injectionId);
-        const labelData = this.edgeRouter?.getInjectoinLabelData(injectionId);
+        const labelData = this.edgeRouter?.getInjectionLabelData(injectionId);
         return this.getInfoElement(info, infoPoint, infoAngle, labelData);
     }
 
     private getEdgesAndInfos(): { edges: SVGGElement; edgeInfos: SVGGElement } {
         // create g edges element
-        const gEdgesElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gEdgesElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gEdgesElement.classList.add(SvgWriter.EDGES_CLASS);
         // create g edge infos element
-        const gEdgeInfosElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gEdgeInfosElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gEdgeInfosElement.classList.add(SvgWriter.EDGE_INFOS_CLASS);
         // add edges
         this.diagramMetadata.edges.forEach((edge) => {
@@ -384,7 +385,7 @@ export class SvgWriter {
 
     private getEdge(edge: EdgeMetadata): SVGGElement {
         const edgeType = MetadataUtils.getEdgeType(edge);
-        const gEdgeElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gEdgeElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gEdgeElement.id = edge.svgId;
         if (DiagramUtils.isHVDCLineEdge(edgeType)) {
             gEdgeElement.classList.add(SvgWriter.HVDC_EDGE_CLASS);
@@ -415,13 +416,13 @@ export class SvgWriter {
         style: string | undefined
     ): SVGPolylineElement | SVGPathElement {
         if (edge.node1 == edge.node2) {
-            const pathElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            const pathElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'path');
             SvgUtils.addCssClasses(pathElement, cssClasses, SvgWriter.EDGE_CLASS);
             SvgUtils.addElementStyle(pathElement, style);
             pathElement.setAttribute('d', DiagramUtils.getHalfLoopPath(points));
             return pathElement;
         } else {
-            const polylineElement = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+            const polylineElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'polyline');
             SvgUtils.addCssClasses(polylineElement, cssClasses, SvgWriter.EDGE_CLASS);
             SvgUtils.addElementStyle(polylineElement, style);
             polylineElement.setAttribute('points', DiagramUtils.getFormattedPolyline(points));
@@ -435,7 +436,7 @@ export class SvgWriter {
         points2: Point[] | undefined,
         edgeType: EdgeType
     ): SVGGElement {
-        const gTranformerElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gTranformerElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         if (points1) {
             gTranformerElement.appendChild(this.getTransformerWinding(points1, edge.classes1, edge.style1));
         }
@@ -453,7 +454,7 @@ export class SvgWriter {
         cssClasses: string[] | undefined,
         style: string | undefined
     ): SVGCircleElement {
-        const transformerCircleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        const transformerCircleElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'circle');
         SvgUtils.addCssClasses(transformerCircleElement, cssClasses, SvgWriter.WINDING_CLASS);
         SvgUtils.addElementStyle(transformerCircleElement, style);
         const circleCenter = DiagramUtils.getPointAtDistance(
@@ -471,7 +472,7 @@ export class SvgWriter {
     }
 
     private getTransformerArrow(points1: Point[] | undefined, points2: Point[] | undefined): SVGPathElement {
-        const arrowPathElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        const arrowPathElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'path');
         arrowPathElement.classList.add(SvgWriter.PST_CLASS);
         const matrix: string = DiagramUtils.getTransformerArrowMatrixString(
             points1,
@@ -484,8 +485,8 @@ export class SvgWriter {
     }
 
     private getHVDCLine(points: Point[]): SVGGElement {
-        const gHVDCLineElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-        const polylineElement = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+        const gHVDCLineElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
+        const polylineElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'polyline');
         polylineElement.classList.add(SvgWriter.HVDC_CLASS);
         const csPoints = DiagramUtils.getConverterStationPoints(points, this.svgParameters.getConverterStationWidth());
         polylineElement.setAttribute('points', DiagramUtils.getFormattedPolyline(csPoints));
@@ -495,7 +496,7 @@ export class SvgWriter {
 
     private getThreeWTEdges(threeWTEdges: EdgeMetadata[]): SVGGElement {
         // create g 3wt edges element
-        const gThreeWTEdgesElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gThreeWTEdgesElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gThreeWTEdgesElement.classList.add(SvgWriter.THREEWT_EDGES_CLASS);
         // add 3wt edges
         threeWTEdges.forEach((edge) => {
@@ -508,7 +509,7 @@ export class SvgWriter {
     }
 
     private getThreeWTEdge(edge: EdgeMetadata, points: Point[]): SVGGElement {
-        const gThreeWTEdgeElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gThreeWTEdgeElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gThreeWTEdgeElement.id = edge.svgId;
         SvgUtils.addCssClasses(gThreeWTEdgeElement, edge.classes1);
         gThreeWTEdgeElement.appendChild(this.getThreeWTPolyline(points));
@@ -516,7 +517,7 @@ export class SvgWriter {
     }
 
     private getThreeWTPolyline(points: Point[]): SVGPolylineElement {
-        const polylineElement = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+        const polylineElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'polyline');
         polylineElement.classList.add(SvgWriter.EDGE_CLASS);
         polylineElement.setAttribute('points', DiagramUtils.getFormattedPolyline(points));
         return polylineElement;
@@ -524,7 +525,7 @@ export class SvgWriter {
 
     private getThreeWTs(threeWTs: NodeMetadata[]): SVGGElement {
         // create g 3wts element
-        const gThreeWTsElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gThreeWTsElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gThreeWTsElement.classList.add(SvgWriter.THREEWTS_CLASS);
         // add 3wts
         threeWTs.forEach((threeWT) => {
@@ -537,7 +538,7 @@ export class SvgWriter {
 
     private getThreeWT(threeWT: NodeMetadata): SVGGElement {
         // create 3wt
-        const gThreeWTElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gThreeWTElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gThreeWTElement.id = threeWT.svgId;
         gThreeWTElement.setAttribute(
             'transform',
@@ -571,7 +572,7 @@ export class SvgWriter {
         points: Point[],
         cssClasses: string[] | undefined
     ): SVGCircleElement {
-        const transformerCircleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        const transformerCircleElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'circle');
         SvgUtils.addCssClasses(transformerCircleElement, cssClasses, SvgWriter.WINDING_CLASS);
         const circleCenter = DiagramUtils.getPointAtDistance(
             points[1],
@@ -593,7 +594,7 @@ export class SvgWriter {
         side: string,
         cssClasses: string[] | undefined
     ): SVGPathElement {
-        const arrowPathElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        const arrowPathElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'path');
         SvgUtils.addCssClasses(arrowPathElement, cssClasses, SvgWriter.WINDING_CLASS);
         const matrix: string = DiagramUtils.getThreeWTArrowMatrixString(
             threeWTPoint,
@@ -620,7 +621,7 @@ export class SvgWriter {
         labelData: LabelData | undefined
     ): SVGGElement {
         // create info element
-        const gInfoElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gInfoElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gInfoElement.id = info.svgId;
         if (infoPoint) {
             gInfoElement.setAttribute('transform', 'translate(' + DiagramUtils.getFormattedPoint(infoPoint) + ')');
@@ -664,7 +665,7 @@ export class SvgWriter {
 
     private getComponentElement(componentType: string, initTrans?: Point): SVGGElement {
         const component = ComponentUtils.getComponent(this.componentLibrary, componentType);
-        const gComponentElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gComponentElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         if (component) {
             const trans = new Point(
                 (initTrans?.x ?? 0) - component.size.width / 2,
@@ -708,7 +709,7 @@ export class SvgWriter {
         type: string | undefined,
         shift: number | undefined
     ): SVGPathElement {
-        const edgeInfoArrowElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        const edgeInfoArrowElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'path');
         if (arrowAngle) {
             let arrowString: string = 'rotate(' + DiagramUtils.getFormattedValue(arrowAngle) + ')';
             if (shift) {
@@ -738,7 +739,7 @@ export class SvgWriter {
         label: string | undefined,
         type: string | undefined
     ): SVGTextElement {
-        const edgeInfoLabelElement = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        const edgeInfoLabelElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'text');
         edgeInfoLabelElement.innerHTML = DiagramUtils.getFormattedInfoLabel(label, type, this.svgParameters);
         edgeInfoLabelElement.setAttribute('transform', 'rotate(' + DiagramUtils.getFormattedValue(angle) + ')');
         edgeInfoLabelElement.setAttribute('x', DiagramUtils.getFormattedValue(shift));
@@ -753,7 +754,7 @@ export class SvgWriter {
     }
 
     private getEdgeMiddleInfo(edge: EdgeMetadata, info: EdgeInfoMetadata): SVGGElement {
-        const gEdgeMiddleInfoElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gEdgeMiddleInfoElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         gEdgeMiddleInfoElement.id = info.svgId;
         const middleInfoPoint = this.edgeRouter?.getEdgeMiddleInfoPoint(edge.svgId);
         if (middleInfoPoint) {
@@ -798,10 +799,10 @@ export class SvgWriter {
 
     private getTextNodesAndEdges(): { textNodes: SVGGElement; textEdges: SVGGElement } {
         // create text nodes g element
-        const textNodesGElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const textNodesGElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         textNodesGElement.classList.add(SvgWriter.TEXT_NODES_CLASS);
         // create text edges g element
-        const textEdgesGElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const textEdgesGElement = document.createElementNS(SvgWriter.SVG_NAMESPACE, 'g');
         textEdgesGElement.classList.add(SvgWriter.TEXT_EDGES_CLASS);
         // create text nodes and edges
         this.diagramMetadata.textNodes.forEach((textNode) => {

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
@@ -7,12 +7,19 @@
  */
 
 import { Point } from '@svgdotjs/svg.js';
-import { BusNodeMetadata, DiagramMetadata, EdgeInfoMetadata, EdgeMetadata, NodeMetadata } from './diagram-metadata';
+import {
+    BusNodeMetadata,
+    DiagramMetadata,
+    EdgeInfoMetadata,
+    EdgeMetadata,
+    InjectionMetadata,
+    NodeMetadata,
+} from './diagram-metadata';
 import * as DiagramUtils from './diagram-utils';
 import { SvgParameters } from './svg-parameters';
 import * as MetadataUtils from './metadata-utils';
 import { EdgeRouter } from './edge-router';
-import { EdgeType } from './diagram-types';
+import { EdgeType, LabelData } from './diagram-types';
 import * as SvgUtils from './svg-utils';
 import { LibraryComponent } from './library-component';
 import DefaultLibraryComponents from '../resources/default-library/components.json';
@@ -26,6 +33,7 @@ export class SvgWriter {
     static readonly THREEWT_EDGES_CLASS = 'nad-3wt-edges';
     static readonly TEXT_NODES_CLASS = 'nad-text-nodes';
     static readonly TEXT_EDGES_CLASS = 'nad-text-edges';
+    static readonly INJECTIONS_CLASS = 'nad-injections';
     static readonly EDGE_CLASS = 'nad-edge-path';
     static readonly HVDC_EDGE_CLASS = 'nad-hvdc-edge';
     static readonly BOUNDARY_LINE_EDGE_CLASS = 'nad-boundary-line-edge';
@@ -95,11 +103,19 @@ export class SvgWriter {
     }
 
     public addSvgContent(svg: SVGSVGElement) {
-        // add nodes
-        svg.appendChild(this.getNodes());
+        // add nodes and injections
+        const nodesAndInjectionsAndInfos = this.getNodesAndInjectionsAndInfos();
+        svg.appendChild(nodesAndInjectionsAndInfos.nodes);
+        if (nodesAndInjectionsAndInfos.injections.hasChildNodes()) {
+            svg.appendChild(nodesAndInjectionsAndInfos.injections);
+        }
         // add edges and infos
         const edgesAndInfos = this.getEdgesAndInfos();
         svg.appendChild(edgesAndInfos.edges);
+        // append injections infos
+        nodesAndInjectionsAndInfos.infos.forEach((info) => {
+            edgesAndInfos.edgeInfos.appendChild(info);
+        });
         svg.appendChild(edgesAndInfos.edgeInfos);
         // add 3wt edges
         if (this.threeWindingsTransformerEdges.length > 0) {
@@ -134,24 +150,38 @@ export class SvgWriter {
         return svg;
     }
 
-    private getNodes(): SVGGElement {
+    private getNodesAndInjectionsAndInfos(): { nodes: SVGGElement; injections: SVGGElement; infos: SVGGElement[] } {
         // create g nodes element
         const gNodesElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         gNodesElement.classList.add(SvgWriter.NODES_CLASS);
+        // create g injections element
+        const gInjectionsElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        gInjectionsElement.classList.add(SvgWriter.INJECTIONS_CLASS);
+        // create injection infos elements list
+        let injectionsInfos: SVGGElement[] = [];
         // add nodes
         this.diagramMetadata.nodes.forEach((node) => {
             if (!node.invisible) {
                 if (MetadataUtils.isThreeWTNode(node)) {
                     this.threeWindingsTransformers.push(node);
                 } else {
-                    gNodesElement.appendChild(this.getNode(node));
+                    const nodeAndInjectsionAndInfos = this.getNodeAndInjectionAndInfos(node);
+                    gNodesElement.appendChild(nodeAndInjectsionAndInfos.node);
+                    if (nodeAndInjectsionAndInfos.injection.hasChildNodes()) {
+                        gInjectionsElement.appendChild(nodeAndInjectsionAndInfos.injection);
+                    }
+                    injectionsInfos = injectionsInfos.concat(nodeAndInjectsionAndInfos.infos);
                 }
             }
         });
-        return gNodesElement;
+        return { nodes: gNodesElement, injections: gInjectionsElement, infos: injectionsInfos };
     }
 
-    private getNode(node: NodeMetadata): SVGGElement {
+    private getNodeAndInjectionAndInfos(node: NodeMetadata): {
+        node: SVGGElement;
+        injection: SVGGElement;
+        infos: SVGGElement[];
+    } {
         // create node
         const gNodeElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         gNodeElement.id = node.svgId;
@@ -163,6 +193,11 @@ export class SvgWriter {
             'transform',
             'translate(' + DiagramUtils.getFormattedPoint(new Point(node.x, node.y)) + ')'
         );
+        // create injection
+        const gInjectionNodeElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        SvgUtils.addCssClasses(gInjectionNodeElement, node.classes);
+        // create injection infos elements list
+        const injectionsInfos: SVGGElement[] = [];
         // add buses
         if (node.unknownBus) {
             const circleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
@@ -181,9 +216,19 @@ export class SvgWriter {
             busNodes.forEach((busNode) => {
                 gNodeElement.appendChild(this.getBusNode(busNode, node, traversingBusEdgesAngles));
                 this.addBusEdgeAngles(node, busNode, busEgdes.get(busNode.svgId) ?? [], traversingBusEdgesAngles);
+                if (this.diagramMetadata.injections) {
+                    const injections: InjectionMetadata[] = MetadataUtils.getInjectionMetadata(
+                        node.svgId,
+                        busNode.svgId,
+                        this.diagramMetadata.injections
+                    );
+                    if (injections.length > 0) {
+                        this.addBusNodeInjections(gInjectionNodeElement, injections, busNode, injectionsInfos);
+                    }
+                }
             });
         }
-        return gNodeElement;
+        return { node: gNodeElement, injection: gInjectionNodeElement, infos: injectionsInfos };
     }
 
     private getBusNode(busNode: BusNodeMetadata, node: NodeMetadata, traversingBusEdgesAngles: number[]): SVGElement {
@@ -246,6 +291,70 @@ export class SvgWriter {
         });
     }
 
+    private addBusNodeInjections(
+        gInjectionNodeElement: SVGGElement,
+        injections: InjectionMetadata[],
+        busNode: BusNodeMetadata,
+        injectionsInfos: SVGGElement[]
+    ) {
+        const gInjectionBusElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        SvgUtils.addCssClasses(gInjectionBusElement, busNode.classes);
+        gInjectionNodeElement.appendChild(gInjectionBusElement);
+
+        injections.forEach((injection) => {
+            const gInjectionElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+            gInjectionElement.id = injection.svgId;
+            SvgUtils.addCssClasses(gInjectionElement, injection.classes);
+            SvgUtils.addElementStyle(gInjectionElement, injection.style);
+            const points = this.edgeRouter?.getInjectionEdgePoints(injection.svgId);
+            if (points) {
+                gInjectionElement.appendChild(this.getInjectionEdge(points));
+                gInjectionElement.appendChild(this.getInjectionIcon(points, injection.componentType));
+            }
+            gInjectionBusElement.appendChild(gInjectionElement);
+
+            if (injection.edgeInfo) {
+                injectionsInfos.push(this.getInjectionInfo(injection.svgId, injection.edgeInfo));
+            }
+        });
+    }
+
+    private getInjectionEdge(points: Point[]): SVGPolylineElement {
+        const polylineInjectionEdgeElement = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+        polylineInjectionEdgeElement.classList.add(SvgWriter.EDGE_CLASS);
+        polylineInjectionEdgeElement.setAttribute('points', DiagramUtils.getFormattedPolyline(points));
+        return polylineInjectionEdgeElement;
+    }
+
+    private getInjectionIcon(points: Point[], componentType: string): SVGGElement {
+        const gInjectionIconElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+
+        const injectionCircleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        const circleCenter = DiagramUtils.getPointAtDistance(
+            points[1],
+            points[0],
+            -this.svgParameters.getInjectionCircleRadius()
+        );
+        injectionCircleElement.setAttribute('cx', DiagramUtils.getFormattedValue(circleCenter.x));
+        injectionCircleElement.setAttribute('cy', DiagramUtils.getFormattedValue(circleCenter.y));
+        injectionCircleElement.setAttribute(
+            'r',
+            DiagramUtils.getFormattedValue(this.svgParameters.getInjectionCircleRadius())
+        );
+        gInjectionIconElement.appendChild(injectionCircleElement);
+
+        gInjectionIconElement.appendChild(this.getComponentElement(componentType, circleCenter));
+
+        return gInjectionIconElement;
+    }
+
+    private getInjectionInfo(injectionId: string, info: EdgeInfoMetadata): SVGGElement {
+        const infoPoint = this.edgeRouter?.getInjectionInfoPoint(injectionId);
+        const infoAngle = this.edgeRouter?.getInjectionInfoAngle(injectionId);
+        const labelData = this.edgeRouter?.getInjectoinLabelData(injectionId);
+        return this.getInfoElement(info, infoPoint, infoAngle, labelData);
+    }
+
     private getEdgesAndInfos(): { edges: SVGGElement; edgeInfos: SVGGElement } {
         // create g edges element
         const gEdgesElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
@@ -260,10 +369,10 @@ export class SvgWriter {
             } else {
                 gEdgesElement.appendChild(this.getEdge(edge));
                 if (edge.edgeInfo1 && !edge.invisible1) {
-                    gEdgeInfosElement.appendChild(this.getEdgeSideInfo(edge, '1', edge.edgeInfo1));
+                    gEdgeInfosElement.appendChild(this.getEdgeSideInfo(edge.svgId, '1', edge.edgeInfo1));
                 }
                 if (edge.edgeInfo2 && !edge.invisible2) {
-                    gEdgeInfosElement.appendChild(this.getEdgeSideInfo(edge, '2', edge.edgeInfo2));
+                    gEdgeInfosElement.appendChild(this.getEdgeSideInfo(edge.svgId, '2', edge.edgeInfo2));
                 }
                 if (edge.edgeInfoMiddle) {
                     gEdgeInfosElement.appendChild(this.getEdgeMiddleInfo(edge, edge.edgeInfoMiddle));
@@ -497,28 +606,38 @@ export class SvgWriter {
         return arrowPathElement;
     }
 
-    private getEdgeSideInfo(edge: EdgeMetadata, side: string, info: EdgeInfoMetadata): SVGGElement {
+    private getEdgeSideInfo(edgeId: string, side: string, info: EdgeInfoMetadata): SVGGElement {
+        const infoPoint = this.edgeRouter?.getEdgeSideinfoPoint(edgeId, side);
+        const infoAngle = this.edgeRouter?.getEdgeSideInfoAngle(edgeId, side);
+        const labelData = this.edgeRouter?.getEdgeSideLabelData(edgeId, side);
+        return this.getInfoElement(info, infoPoint, infoAngle, labelData);
+    }
+
+    private getInfoElement(
+        info: EdgeInfoMetadata,
+        infoPoint: Point | undefined,
+        infoAngle: number | undefined,
+        labelData: LabelData | undefined
+    ): SVGGElement {
         // create info element
-        const gEdgeInfoElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-        gEdgeInfoElement.id = info.svgId;
-        const infoPoint = this.edgeRouter?.getEdgeSideinfoPoint(edge.svgId, side);
+        const gInfoElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        gInfoElement.id = info.svgId;
         if (infoPoint) {
-            gEdgeInfoElement.setAttribute('transform', 'translate(' + DiagramUtils.getFormattedPoint(infoPoint) + ')');
+            gInfoElement.setAttribute('transform', 'translate(' + DiagramUtils.getFormattedPoint(infoPoint) + ')');
         }
         if (info.componentType) {
-            gEdgeInfoElement.appendChild(this.getEdgeInfoComponent(info.componentType));
+            gInfoElement.appendChild(this.getComponentElement(info.componentType));
         } else {
             // add arrows
-            this.addEdgeInfoArrows(gEdgeInfoElement, info, this.edgeRouter?.getEdgeSideInfoAngle(edge.svgId, side));
+            this.addEdgeInfoArrows(gInfoElement, info, infoAngle);
         }
         // add labels
-        const labelData = this.edgeRouter?.getEdgeSideLabelData(edge.svgId, side);
-        if (labelData === undefined) return gEdgeInfoElement;
+        if (labelData === undefined) return gInfoElement;
         const factor: number =
             info.directionA && info.directionB ? this.svgParameters.getDoubleArrowShiftFactorText() : 1;
         // add labelB element
         if (info.labelB) {
-            gEdgeInfoElement.appendChild(
+            gInfoElement.appendChild(
                 this.getEdgeInfoLabel(
                     labelData.angle,
                     labelData.external.shift * factor,
@@ -530,7 +649,7 @@ export class SvgWriter {
         }
         // add labelA element
         if (info.labelA) {
-            gEdgeInfoElement.appendChild(
+            gInfoElement.appendChild(
                 this.getEdgeInfoLabel(
                     labelData.angle,
                     labelData.internal.shift * factor,
@@ -540,23 +659,26 @@ export class SvgWriter {
                 )
             );
         }
-        return gEdgeInfoElement;
+        return gInfoElement;
     }
 
-    private getEdgeInfoComponent(componentType: string): SVGGElement {
+    private getComponentElement(componentType: string, initTrans?: Point): SVGGElement {
         const component = ComponentUtils.getComponent(this.componentLibrary, componentType);
-        const edgeInfoComponent = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const gComponentElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
         if (component) {
-            const trans = new Point(-component.size.width / 2, -component.size.height / 2);
-            edgeInfoComponent.setAttribute('transform', 'translate(' + DiagramUtils.getFormattedPoint(trans) + ')');
-            edgeInfoComponent.classList.add(component.styleClass);
+            const trans = new Point(
+                (initTrans?.x ?? 0) - component.size.width / 2,
+                (initTrans?.y ?? 0) - component.size.height / 2
+            );
+            gComponentElement.setAttribute('transform', 'translate(' + DiagramUtils.getFormattedPoint(trans) + ')');
+            gComponentElement.classList.add(component.styleClass);
             component.subComponents.forEach((subComponent) => {
                 void ComponentUtils.getComponentPath(subComponent.fileName, this.urlResolver).then((path) => {
-                    edgeInfoComponent.appendChild(path);
+                    gComponentElement.appendChild(path);
                 });
             });
         }
-        return edgeInfoComponent;
+        return gComponentElement;
     }
 
     private addEdgeInfoArrows(
@@ -641,13 +763,13 @@ export class SvgWriter {
             );
         }
         if (info.componentType) {
-            gEdgeMiddleInfoElement.appendChild(this.getEdgeInfoComponent(info.componentType));
+            gEdgeMiddleInfoElement.appendChild(this.getComponentElement(info.componentType));
         } else {
             // add arrows
             this.addEdgeInfoArrows(gEdgeMiddleInfoElement, info, this.edgeRouter?.getEdgeMiddleInfoAngle(edge.svgId));
         }
         // add labels
-        let x = 0;
+        let shift = 0;
         let style: string | undefined = 'text-anchor:middle';
         const labelData = this.edgeRouter?.getEdgeMiddleLabelData(edge.svgId);
         if (labelData === undefined) return gEdgeMiddleInfoElement;
@@ -664,12 +786,12 @@ export class SvgWriter {
                     info.infoTypeB
                 )
             );
-            x = labelData.internal.shift * factor;
+            shift = labelData.internal.shift * factor;
             style = labelData.internal.style;
         }
         // add labelA element
         gEdgeMiddleInfoElement.appendChild(
-            this.getEdgeInfoLabel(labelData.angle, x, style, info.labelA, info.infoTypeA)
+            this.getEdgeInfoLabel(labelData.angle, shift, style, info.labelA, info.infoTypeA)
         );
         return gEdgeMiddleInfoElement;
     }

--- a/packages/network-viewer-core/src/resources/default-library/battery.svg
+++ b/packages/network-viewer-core/src/resources/default-library/battery.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="50" height="50" style="fill:none; stroke:black; stroke-width: 3">
+    <path d="m9,17 h32 v18 h-32z M14,17 v-2 h6 v2 M30,17 v-2 h6 v2 M13.5,24 h7 M29.5,24 h7 M33,20.5 v7"/>
+</svg>

--- a/packages/network-viewer-core/src/resources/default-library/capacitor.svg
+++ b/packages/network-viewer-core/src/resources/default-library/capacitor.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" standalone="no"?>
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="50" height="50" style="fill:none; stroke:black; stroke-width: 3">
+    <path d="M25,12 v10 M10,22 h30 M10,28 h30 M25,28 v10"/>
+</svg>
+

--- a/packages/network-viewer-core/src/resources/default-library/components.json
+++ b/packages/network-viewer-core/src/resources/default-library/components.json
@@ -1,5 +1,117 @@
 [
   {
+    "type": "LOAD",
+    "size": {
+      "width": 50.0,
+      "height": 50.0
+    },
+    "subComponents": [
+      {
+        "name": "LOAD",
+        "fileName": "load.svg"
+      }
+    ],
+    "styleClass": "nad-load"
+  },
+  {
+    "type": "BATTERY",
+    "size": {
+      "width": 50.0,
+      "height": 50.0
+    },
+    "subComponents": [
+      {
+        "name": "BATTERY",
+        "fileName": "battery.svg"
+      }
+    ],
+    "styleClass": "nad-battery"
+  },
+  {
+    "type": "GENERATOR",
+    "size": {
+      "width": 50.0,
+      "height": 50.0
+    },
+    "subComponents": [
+      {
+        "name": "GENERATOR",
+        "fileName": "generator.svg"
+      }
+    ],
+    "styleClass": "nad-generator"
+  },
+  {
+    "type": "SHUNT_COMPENSATOR_CAPACITOR",
+    "size": {
+      "width": 50.0,
+      "height": 50.0
+    },
+    "subComponents": [
+      {
+        "name": "CAPACITOR",
+        "fileName": "capacitor.svg"
+      }
+    ],
+    "styleClass": "nad-capacitor"
+  },
+  {
+    "type": "SHUNT_COMPENSATOR_INDUCTOR",
+    "size": {
+      "width": 50.0,
+      "height": 50.0
+    },
+    "subComponents": [
+      {
+        "name": "INDUCTOR",
+        "fileName": "inductor.svg"
+      }
+    ],
+    "styleClass": "nad-inductor"
+  },
+  {
+    "type": "STATIC_VAR_COMPENSATOR",
+    "size": {
+      "width": 50.0,
+      "height": 50.0
+    },
+    "subComponents": [
+      {
+        "name": "STATIC_VAR_COMPENSATOR",
+        "fileName": "svc.svg"
+      }
+    ],
+    "styleClass": "nad-svc"
+  },
+  {
+    "type": "LCC",
+    "size": {
+      "width": 50.0,
+      "height": 50.0
+    },
+    "subComponents": [
+      {
+        "name": "LCC",
+        "fileName": "lcc.svg"
+      }
+    ],
+    "styleClass": "nad-lcc"
+  },
+  {
+    "type": "VSC",
+    "size": {
+      "width": 50.0,
+      "height": 50.0
+    },
+    "subComponents": [
+      {
+        "name": "VSC",
+        "fileName": "vsc.svg"
+      }
+    ],
+    "styleClass": "nad-vsc"
+  },
+  {
     "type": "LOCK",
     "size": {
       "width": 50.0,

--- a/packages/network-viewer-core/src/resources/default-library/generator.svg
+++ b/packages/network-viewer-core/src/resources/default-library/generator.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="50" height="50" style="fill:none; stroke:black; stroke-width: 3; stroke-linecap:round">
+    <path d="M10,25 A 15 50 0 0 1 25,25 A 15 50 0 0 0 40,25"/>
+</svg> 

--- a/packages/network-viewer-core/src/resources/default-library/inductor.svg
+++ b/packages/network-viewer-core/src/resources/default-library/inductor.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="50" height="50" style="fill:none; stroke:black; stroke-width: 3; stroke-linejoin:round; stroke-linecap:round">
+    <path d="M43,28 A 8 20 0 0 0 31,28 A 8 20 0 0 0 19,28 A 8 20 0 0 0 7,28"/>
+</svg>

--- a/packages/network-viewer-core/src/resources/default-library/lcc.svg
+++ b/packages/network-viewer-core/src/resources/default-library/lcc.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="no"?>
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+     width="50" height="50"
+     style="fill:none; stroke:black; stroke-width: 3; stroke-linecap:round">
+  <path d="M10.86,39.14 L40,15" />
+  <path d="M9,22 A 3.5 3.5 0 0 1 16,22 A 3.5 3.5 0 0 0 23,22"/>
+  <path d="M24,34 H40 M24,39 H27 M30.5,39 H33.5 M37,39 H40" />
+  <path d="M14,7 L14,14 L19,14 M27,7.5 A 3.5 3.5 0 1 0 27,13.5 M35.5,7.5 A 3.5 3.5 0 1 0 35.5,13.5" />
+</svg>

--- a/packages/network-viewer-core/src/resources/default-library/load.svg
+++ b/packages/network-viewer-core/src/resources/default-library/load.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" standalone="no"?>
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="50" height="50" style="fill:none; stroke:black; stroke-width:3px">
+    <path d="M7.3223,7.3223 42.6777,42.6777 M42.6777,7.3223 7.3223,42.6777"/>
+</svg>

--- a/packages/network-viewer-core/src/resources/default-library/svc.svg
+++ b/packages/network-viewer-core/src/resources/default-library/svc.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="50" height="50" style="fill:none; stroke:black; stroke-width: 3; stroke-linejoin:round">
+  <path d="M25,12 v10 M10,22 h30 M10,28 h30 M25,28 v10 M14,36 36,14 M32,14 36,14 36,18z"/>
+</svg>

--- a/packages/network-viewer-core/src/resources/default-library/vsc.svg
+++ b/packages/network-viewer-core/src/resources/default-library/vsc.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="no"?>
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+     width="50" height="50"
+     style="fill:none; stroke:black; stroke-width: 3; stroke-linecap:round">
+  <path d="M10.86,39.14 L40,15" />
+  <path d="M9,22 A 3.5 3.5 0 0 1 16,22 A 3.5 3.5 0 0 0 23,22"/>
+  <path d="M24,34 H40 M24,39 H27 M30.5,39 H33.5 M37,39 H40" />
+  <path d="M14,7 L16.5,14 M16.5,14 L19.5,7 M26.5,7 A 2 1.2 0 1 0 24.75,10.5 A 2 1.2 0 1 1 23,14 M35.5,7.5 A 3.5 3.5 0 1 0 35.5,13.5" />
+</svg>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
feature



**What is the current behavior?**
In the NAD viewer, the SVG writer that creates the SVG starting from diagram metadata does not add injections


**What is the new behavior (if this is a feature change)?**
In the NAD viewer, the SVG writer that creates the SVG starting from diagram metadata adds also injections


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No