### PR TITLE
Warn when network contains voltage levels without substation instead of throw

### DIFF
--- a/packages/network-map-layers/src/network/geo-data.ts
+++ b/packages/network-map-layers/src/network/geo-data.ts
@@ -100,11 +100,21 @@ export class GeoData {
     getLinePositions(network: MapEquipments, line: MapAnyLine, detailed = true): LonLat[] {
         const voltageLevel1 = network.getVoltageLevel(line.voltageLevelId1);
         if (!voltageLevel1) {
-            throw new Error(`Voltage level side 1 '${line.voltageLevelId1}' not found`);
+            console.warn(`Cannot draw line '${line.id}': voltage level side 1 '${line.voltageLevelId1}' not found`);
         }
         const voltageLevel2 = network.getVoltageLevel(line.voltageLevelId2);
         if (!voltageLevel2) {
-            throw new Error(`Voltage level side 2 '${line.voltageLevelId2}' not found`);
+            console.warn(`Cannot draw line '${line.id}': voltage level side 2 '${line.voltageLevelId2}' not found`);
+        }
+        if (!voltageLevel1 || !voltageLevel2) {
+            // A line can reference a voltage level which is not attached to a substation.
+            // Such a voltage level is not part of the map equipment index, so there is no
+            // reliable position from which to draw the line. Return an invisible line,
+            // consistently with the handling of substations without geo-data.
+            return [
+                [0, 0],
+                [0, 0],
+            ];
         }
         const substationPosition1 = this.getSubstationPosition(voltageLevel1.substationId);
         const substationPosition2 = this.getSubstationPosition(voltageLevel2.substationId);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When displaying the map with a network where there are voltage level without substations (which is allowed in powsybl impl), the map is not displayed.


**What is the new behavior (if this is a feature change)?**
When displaying the map with a network where there are voltage level without substations (which is allowed in powsybl impl), the map is displayed and a warning is issued in the console.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No