### PR TITLE
Fix non-fatal coverage and licenses check error in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build workspaces
+        run: npm run build --workspaces
+
       - name: Lint
         run: npm run lint
 
@@ -65,7 +68,7 @@ jobs:
         run: npm run licenses-check
 
       - name: Build
-        run: npm run build:all
+        run: npm run build
 
   sonar:
     name: SonarCloud Scan

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
     if: github.event.pull_request.head.repo.fork == false
     container:
       image: mcr.microsoft.com/playwright:v1.61.0-noble
-      options: --user 1001
     steps:
       - name: Checkout sources
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -41,6 +40,11 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
+
+      - name: Install jq
+        run: |
+          apt-get update
+          apt-get install --yes --no-install-recommends jq
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/fork-build-tests.yml
+++ b/.github/workflows/fork-build-tests.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build workspaces
+        run: npm run build --workspaces
+
       - name: Lint
         run: npm run lint
 
@@ -45,7 +48,7 @@ jobs:
         run: npm run licenses-check
 
       - name: Build
-        run: npm run build:all
+        run: npm run build
 
       - name: Save build artifacts and coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/fork-build-tests.yml
+++ b/.github/workflows/fork-build-tests.yml
@@ -11,7 +11,6 @@ jobs:
     if: github.event.pull_request.head.repo.fork == true
     container:
       image: mcr.microsoft.com/playwright:v1.61.0-noble
-      options: --user 1001
     steps:
       - name: Checkout sources
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -21,6 +20,11 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
+
+      - name: Install jq
+        run: |
+          apt-get update
+          apt-get install --yes --no-install-recommends jq
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The workspace packages are now built before running the coverage tests. Their package exports point to files in dist, so running coverage before the build prevented Vite from resolving them. Vitest treated these resolution and parsing errors as non-fatal and excluded the affected files, resulting in incomplete coverage while the CI still passed. The final build step now only builds the root package, avoiding rebuilding the workspaces.
Also install jq in the CI for the licenses check.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix coverage error, which was non-fatal :

> 2026-08-04T13:21:10.4594446Z [2m1:21:10 PM[22m [31m[1m[vite][22m[39m [31m[2m(client)[22m[39m Pre-transform error: Failed to resolve entry for package "@powsybl/network-map-layers". The package may have incorrect main/module/exports specified in its package.json.
> 2026-08-04T13:21:10.4596424Z   Plugin: [35mvite:import-analysis[39m
> 2026-08-04T13:21:10.4597448Z   File: [36m/__w/powsybl-network-viewer/powsybl-network-viewer/src/components/network-map-viewer/network/network-map.tsx[39m:30:7
> 2026-08-04T13:21:10.4598290Z [33m  10 |    LineLayer,
> 2026-08-04T13:21:10.4598591Z   11 |    SubstationLayer
> 2026-08-04T13:21:10.4598960Z   12 |  } from "@powsybl/network-map-layers";
> 2026-08-04T13:21:10.4599630Z      |          ^
> 2026-08-04T13:21:10.4600127Z   13 |  import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
> 2026-08-04T13:21:10.4600774Z   14 |  import mapboxgl from "mapbox-gl";[39m
> 2026-08-04T13:21:10.4627153Z Failed to parse file:///__w/powsybl-network-viewer/powsybl-network-viewer/src/index.ts. Excluding it from coverage.
> 2026-08-04T13:21:10.4628138Z  Error [RollupError]: Expected ',', got 'ident'
> 2026-08-04T13:21:10.4629268Z     at getRollupError (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/rollup/dist/es/shared/parseAst.js:406:41)
> 2026-08-04T13:21:10.4630542Z     at convertProgram (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/rollup/dist/es/shared/parseAst.js:1132:26)
> 2026-08-04T13:21:10.4632358Z     at parseAstAsync (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/rollup/dist/es/shared/parseAst.js:2122:106)
> 2026-08-04T13:21:10.4634389Z     at V8CoverageProvider.remapCoverage (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/@vitest/coverage-v8/dist/provider.js:133:10)
> 2026-08-04T13:21:10.4636052Z     at file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/@vitest/coverage-v8/dist/provider.js:119:23
> 2026-08-04T13:21:10.4636974Z     at async Promise.all (index 0)
> 2026-08-04T13:21:10.4638191Z     at V8CoverageProvider.getCoverageMapForUncoveredFiles (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/@vitest/coverage-v8/dist/provider.js:109:4)
> 2026-08-04T13:21:10.4640031Z     at V8CoverageProvider.generateCoverage (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/@vitest/coverage-v8/dist/provider.js:56:29)
> 2026-08-04T13:21:10.4641212Z     at file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/vitest/dist/chunks/cli-api.24X8XwN1.js:13604:23
> 2026-08-04T13:21:10.4642245Z     at file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/vitest/dist/chunks/cli-api.24X8XwN1.js:13617:11 {
> 2026-08-04T13:21:10.4642891Z   code: 'PARSE_ERROR',
> 2026-08-04T13:21:10.4643118Z   pos: 386
> 2026-08-04T13:21:10.4643304Z }
> 2026-08-04T13:21:10.9653944Z Failed to parse file:///__w/powsybl-network-viewer/powsybl-network-viewer/src/components/network-map-viewer/network/network-map.tsx. Excluding it from coverage.
> 2026-08-04T13:21:10.9655768Z  Error [RollupError]: Expected ',', got 'ident'
> 2026-08-04T13:21:10.9657255Z     at getRollupError (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/rollup/dist/es/shared/parseAst.js:406:41)
> 2026-08-04T13:21:10.9659401Z     at convertProgram (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/rollup/dist/es/shared/parseAst.js:1132:26)
> 2026-08-04T13:21:10.9661142Z     at parseAstAsync (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/rollup/dist/es/shared/parseAst.js:2122:106)
> 2026-08-04T13:21:10.9663090Z     at V8CoverageProvider.remapCoverage (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/@vitest/coverage-v8/dist/provider.js:133:10)
> 2026-08-04T13:21:10.9664896Z     at file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/@vitest/coverage-v8/dist/provider.js:119:23
> 2026-08-04T13:21:10.9665905Z     at async Promise.all (index 1)
> 2026-08-04T13:21:10.9667362Z     at V8CoverageProvider.getCoverageMapForUncoveredFiles (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/@vitest/coverage-v8/dist/provider.js:109:4)
> 2026-08-04T13:21:10.9670027Z     at V8CoverageProvider.generateCoverage (file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/@vitest/coverage-v8/dist/provider.js:56:29)
> 2026-08-04T13:21:10.9671920Z     at file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/vitest/dist/chunks/cli-api.24X8XwN1.js:13604:23
> 2026-08-04T13:21:10.9673590Z     at file:///__w/powsybl-network-viewer/powsybl-network-viewer/node_modules/vitest/dist/chunks/cli-api.24X8XwN1.js:13617:11 {
> 2026-08-04T13:21:10.9674621Z   code: 'PARSE_ERROR',
> 2026-08-04T13:21:10.9675016Z   pos: 280
> 2026-08-04T13:21:10.9675346Z }


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Build dependencies package after the coverage test


**What is the new behavior (if this is a feature change)?**
Build dependencies package before the coverage test


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
