### PR TITLE
[nad-viewer] Merge half edges when drawing lines in SVG creation

### DIFF
--- a/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-utils.test.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-utils.test.ts
@@ -10,6 +10,7 @@ import * as DiagramUtils from './diagram-utils';
 import { DiagramPaddingMetadata, SvgParametersMetadata } from './diagram-metadata';
 import { Point } from '@svgdotjs/svg.js';
 import { SvgParameters } from './svg-parameters';
+import { EdgeType } from './diagram-types';
 
 test('getFormattedValue', () => {
     expect(DiagramUtils.getFormattedValue(12)).toBe('12.00');
@@ -428,4 +429,20 @@ test('getVLThreshold', () => {
     voltageLevelTheshold = DiagramUtils.getVLThreshold(voltageLevelThesholds, 500);
     expect(voltageLevelTheshold.threshold).toBe(4000);
     expect(voltageLevelTheshold.voltageLevels?.length).toBe(2);
+});
+
+test('isLineEdge', () => {
+    expect(DiagramUtils.isLineEdge(EdgeType.LINE)).toBe(true);
+    expect(DiagramUtils.isLineEdge(EdgeType.TWO_WINDINGS_TRANSFORMER)).toBe(false);
+    expect(DiagramUtils.isLineEdge(EdgeType.BOUNDARY_LINE)).toBe(true);
+    expect(DiagramUtils.isLineEdge(EdgeType.HVDC_LINE_LCC)).toBe(true);
+});
+
+test('sameArray', () => {
+    expect(DiagramUtils.sameArray(['a', 'b', 'c'], ['a', 'b', 'c'])).toBe(true);
+    expect(DiagramUtils.sameArray(['a', 'b', 'c'], ['c', 'a', 'b'])).toBe(true);
+    expect(DiagramUtils.sameArray(['a', 'b', 'c'], ['a', 'b', 'd'])).toBe(false);
+    expect(DiagramUtils.sameArray(['a', 'b', 'c'], ['a', 'b', 'c', 'd'])).toBe(false);
+    expect(DiagramUtils.sameArray(['a', 'b', 'c'], undefined)).toBe(false);
+    expect(DiagramUtils.sameArray(undefined, undefined)).toBe(true);
 });

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-utils.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/diagram-utils.ts
@@ -344,6 +344,10 @@ export function isBoundaryLineEdge(edgeType: EdgeType): boolean {
     return edgeType == EdgeType.BOUNDARY_LINE;
 }
 
+export function isLineEdge(edgeType: EdgeType): boolean {
+    return edgeType == EdgeType.LINE || isBoundaryLineEdge(edgeType) || isHVDCLineEdge(edgeType);
+}
+
 // get the points of a converter station of an HVDC line edge
 export function getConverterStationPoints(halfEdgePoints: Point[], converterStationWidth: number): [Point, Point] {
     const halfWidth = converterStationWidth / 2;
@@ -451,4 +455,8 @@ export function getVLThreshold(
 
 export function intersectionLength(array1: string[] | undefined, array2: string[] | undefined): number {
     return array1?.filter((value) => array2?.includes(value)).length ?? 0;
+}
+
+export function sameArray(array1: string[] | undefined, array2: string[] | undefined): boolean {
+    return array1?.length == array2?.length && JSON.stringify(array1?.sort()) === JSON.stringify(array2?.sort());
 }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer.ts
@@ -178,7 +178,7 @@ export class NetworkAreaDiagramViewer {
         this.diagramMetadata = diagramMetadata;
         this.nadViewerParameters = new NadViewerParameters(nadViewerParametersOptions ?? undefined);
         if (this.nadViewerParameters.getCreateSvgFromMetadata() && this.diagramMetadata != null) {
-            this.svgWriter = new SvgWriter({ diagramMetadata: this.diagramMetadata });
+            this.svgWriter = new SvgWriter({ diagramMetadata: this.diagramMetadata, mergeLines: true });
             this.svgContent = this.svgWriter.getEmptySvg();
         }
         this.width = 0;
@@ -544,6 +544,9 @@ export class NetworkAreaDiagramViewer {
             nodes.classList.add('nad-vl-nodes');
             this.innerSvg?.appendChild(nodes);
         }
+        if (this.nadViewerParameters.getAdaptiveTextZoom().enabled) {
+            nodes.replaceChildren();
+        }
         return nodes;
     }
 
@@ -553,6 +556,9 @@ export class NetworkAreaDiagramViewer {
             edges = document.createElementNS('http://www.w3.org/2000/svg', 'g');
             edges.classList.add('nad-branch-edges');
             this.innerSvg?.appendChild(edges);
+        }
+        if (this.nadViewerParameters.getAdaptiveTextZoom().enabled) {
+            edges.replaceChildren();
         }
         return edges;
     }
@@ -2200,6 +2206,7 @@ export class NetworkAreaDiagramViewer {
                 elementList: { nodes: nodes, edges: edges },
                 voltageLevels: maxDisplayedSize > edgeVlThreshold.threshold ? edgeVlThreshold.voltageLevels : undefined,
                 metadataSearch: this.metadataSearch,
+                mergeLines: true,
             });
             svgWriter.addNodes(<SVGGElement>this.nodesSection!);
             svgWriter.addEdgesAndInfos(<SVGGElement>this.edgesSection!);

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer-parameters.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer-parameters.ts
@@ -21,4 +21,7 @@ export interface SvgWriterParameters {
 
     // object for searching diagram metadata
     metadataSearch?: MetadataSearch;
+
+    // whether merge half edges of lines
+    mergeLines?: boolean;
 }

--- a/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
+++ b/packages/network-viewer-core/src/network-area-diagram-viewer/svg-writer.ts
@@ -38,7 +38,9 @@ export class SvgWriter {
 
     diagramMetadata: DiagramMetadata;
     svgParameters: SvgParameters;
+    svgWriterParameters: SvgWriterParameters;
     edgeRouter: EdgeRouter | undefined;
+    metadataSearch: MetadataSearch | undefined;
     threeWindingsTransformers: NodeMetadata[] = [];
     threeWindingsTransformerEdges: EdgeMetadata[] = [];
     windingSideMapping: { [key: number]: string } = {
@@ -47,20 +49,17 @@ export class SvgWriter {
         3: 'THREE',
     };
 
-    nodes: NodeMetadata[] | undefined = undefined;
-    edges: EdgeMetadata[] | undefined = undefined;
-    voltageLevels: string[] | undefined;
-    metadataSearch: MetadataSearch | undefined;
-
     constructor(svgWriterParameters: SvgWriterParameters) {
         this.diagramMetadata = svgWriterParameters.diagramMetadata;
         this.svgParameters = new SvgParameters(this.diagramMetadata.svgParameters);
-        this.nodes = svgWriterParameters.elementList?.nodes;
-        this.edges = svgWriterParameters.elementList?.edges;
-        this.voltageLevels = svgWriterParameters.voltageLevels;
+        this.svgWriterParameters = svgWriterParameters;
         this.metadataSearch = svgWriterParameters.metadataSearch;
         // get edge router, for computing edges points
-        this.edgeRouter = new EdgeRouter(this.diagramMetadata, this.edges, this.metadataSearch);
+        this.edgeRouter = new EdgeRouter(
+            this.diagramMetadata,
+            this.svgWriterParameters.elementList?.edges,
+            this.metadataSearch
+        );
     }
 
     public getSvg(textBoxSize?: { width: number; height: number }): string {
@@ -140,7 +139,7 @@ export class SvgWriter {
     }
 
     public addNodes(gNodesElement: SVGGElement) {
-        (this.nodes ?? this.diagramMetadata.nodes).forEach((node) => {
+        (this.svgWriterParameters.elementList?.nodes ?? this.diagramMetadata.nodes).forEach((node) => {
             if (!node.invisible) {
                 const nodeElement = gNodesElement.querySelector(":scope > [id='" + node.svgId + "']") ?? null;
                 if (nodeElement) return;
@@ -267,7 +266,7 @@ export class SvgWriter {
     }
 
     public addEdgesAndInfos(gEdgesElement: SVGGElement, gEdgeInfosElement?: SVGGElement) {
-        (this.edges ?? this.diagramMetadata.edges).forEach((edge) => {
+        (this.svgWriterParameters.elementList?.edges ?? this.diagramMetadata.edges).forEach((edge) => {
             if (MetadataUtils.isThreeWTEdge(edge)) {
                 this.threeWindingsTransformerEdges.push(edge);
             } else {
@@ -298,20 +297,31 @@ export class SvgWriter {
             gEdgeElement.classList.add(SvgWriter.BOUNDARY_LINE_EDGE_CLASS);
         }
         const halfEdgePoints1 = this.edgeRouter?.getEdgePoints(edge.svgId, '1');
-        if (
-            halfEdgePoints1 &&
-            !edge.invisible1 &&
-            DiagramUtils.intersectionLength(edge.classes1, this.voltageLevels) == 0
-        ) {
-            gEdgeElement.appendChild(this.getHalfEdge(edge, halfEdgePoints1, edge.classes1, edge.style1));
-        }
         const halfEdgePoints2 = this.edgeRouter?.getEdgePoints(edge.svgId, '2');
         if (
+            halfEdgePoints1 &&
             halfEdgePoints2 &&
-            !edge.invisible2 &&
-            DiagramUtils.intersectionLength(edge.classes2, this.voltageLevels) == 0
+            this.svgWriterParameters.mergeLines &&
+            this.canMergeEdge(edge, edgeType)
         ) {
-            gEdgeElement.appendChild(this.getHalfEdge(edge, halfEdgePoints2, edge.classes2, edge.style2));
+            gEdgeElement.appendChild(
+                this.getMergedEdge(edge, halfEdgePoints1, halfEdgePoints2, edge.classes1, edge.style1)
+            );
+        } else {
+            if (
+                halfEdgePoints1 &&
+                !edge.invisible1 &&
+                DiagramUtils.intersectionLength(edge.classes1, this.svgWriterParameters.voltageLevels) == 0
+            ) {
+                gEdgeElement.appendChild(this.getHalfEdge(edge, halfEdgePoints1, edge.classes1, edge.style1));
+            }
+            if (
+                halfEdgePoints2 &&
+                !edge.invisible2 &&
+                DiagramUtils.intersectionLength(edge.classes2, this.svgWriterParameters.voltageLevels) == 0
+            ) {
+                gEdgeElement.appendChild(this.getHalfEdge(edge, halfEdgePoints2, edge.classes2, edge.style2));
+            }
         }
         if (DiagramUtils.isTransformerEdge(edgeType) && (halfEdgePoints1 || halfEdgePoints2)) {
             gEdgeElement.appendChild(this.getTransformer(edge, halfEdgePoints1, halfEdgePoints2, edgeType));
@@ -320,6 +330,43 @@ export class SvgWriter {
             gEdgeElement.appendChild(this.getHVDCLine(halfEdgePoints1));
         }
         return gEdgeElement;
+    }
+
+    private canMergeEdge(edge: EdgeMetadata, edgeType: EdgeType): boolean {
+        return (
+            DiagramUtils.isLineEdge(edgeType) &&
+            edge.invisible1 !== true &&
+            edge.invisible2 !== true &&
+            DiagramUtils.sameArray(edge.classes1, edge.classes2) &&
+            edge.style1 == edge.style2
+        );
+    }
+
+    private getMergedEdge(
+        edge: EdgeMetadata,
+        points1: Point[],
+        points2: Point[],
+        cssClasses: string[] | undefined,
+        style: string | undefined
+    ): any {
+        if (edge.node1 == edge.node2) {
+            const pathElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            SvgUtils.addCssClasses(pathElement, cssClasses, SvgWriter.EDGE_CLASS);
+            SvgUtils.addElementStyle(pathElement, style);
+            pathElement.setAttribute(
+                'd',
+                DiagramUtils.getHalfLoopPath(points1).concat(' ' + DiagramUtils.getHalfLoopPath(points2))
+            );
+            return pathElement;
+        } else {
+            const polylineElement = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+            SvgUtils.addCssClasses(polylineElement, cssClasses, SvgWriter.EDGE_CLASS);
+            SvgUtils.addElementStyle(polylineElement, style);
+            points1 = points1.slice(0, -1);
+            points2 = points2.slice(0, -1).reverse();
+            polylineElement.setAttribute('points', DiagramUtils.getFormattedPolyline(points1.concat(points2)));
+            return polylineElement;
+        }
     }
 
     private getHalfEdge(
@@ -350,10 +397,10 @@ export class SvgWriter {
         edgeType: EdgeType
     ): SVGGElement {
         const gTranformerElement = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-        if (points1 && DiagramUtils.intersectionLength(edge.classes1, this.voltageLevels) == 0) {
+        if (points1 && DiagramUtils.intersectionLength(edge.classes1, this.svgWriterParameters.voltageLevels) == 0) {
             gTranformerElement.appendChild(this.getTransformerWinding(points1, edge.classes1, edge.style1));
         }
-        if (points2 && DiagramUtils.intersectionLength(edge.classes2, this.voltageLevels) == 0) {
+        if (points2 && DiagramUtils.intersectionLength(edge.classes2, this.svgWriterParameters.voltageLevels) == 0) {
             gTranformerElement.appendChild(this.getTransformerWinding(points2, edge.classes2, edge.style2));
         }
         if (edgeType == EdgeType.PHASE_SHIFT_TRANSFORMER) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
feature



**What is the current behavior?**
in the NAD viewer, the `SvgWriter`, when creating line edges, creates two half edges (two polylines) for each line, as it is done in the Network Area Diagram project.



**What is the new behavior (if this is a feature change)?**
the `SvgWriter`, according to a parameter, when creating line edges, can merge the two half edges, creating a single polyline for a line. The goal is to reduce the SVG size, maintaining the visual aspect of the diagram.



**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
The SvgWriterParameters contains a new optional parameter mergeLines, for requiring the drawing of a single polyline for the lines.
The created SVG is different from the original one, containing a single poyline for each line.



**Other information**:
The change of the SVG structure requires an adaptation in the node moving functionality. Without this adaptation the node moving does not work properly: some half edges disappear, when the node is moved. This adaptation in the node moving functionality is not yet included in this PR. 
