### PR TITLE
Add SVG NAD performance benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ To fix this, run this command from the app **after** running "npm install"
 - Unit tests (fast): `npm run test:unit`
 - Browser visual screenshots (Vitest browser mode): `npm run test:browser`
 - Update screenshot baselines: `npm run test:browser -- -u`
+- SVG NAD performance benchmark (the matching `_metadata.json` file is selected automatically):
+  `NAD_SVG=demo/src/diagram-viewers/data/case1354pegase.svg npm run test:browser:performance`
+  Set `NAD_METADATA=/path/to/metadata.json` as well when the metadata file does not follow the usual
+  `<svg-name>_metadata.json` convention.
 
 According to PowSyBl [branching and release strategy](https://github.com/powsybl/.github/blob/main/BRANCHING_RELEASE_STRATEGY.md), 
 if you want to publish a new release of powsybl-network-viewer in the 
@@ -212,4 +216,3 @@ See [Contributing.md](https://github.com/powsybl/.github/blob/main/CONTRIBUTING.
 on how to contribute to the code.
 
 See [Security.md](https://github.com/powsybl/.github/blob/main/SECURITY.md) to read about the security policy.
-

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,6 +23,7 @@
             <h3>Contents</h3>
             <ul>
                 <li><a href="index.html">Network area diagram viewers</a></li>
+                <li><a href="nad-svg.html">SVG NAD browser</a></li>
                 <li><a href="map-viewer.html">Map viewers</a></li>
                 <li><a href="sld.html">Single-line diagram viewers</a></li>
                 <li><a href="synced-viewers.html">Synced viewers demo</a></li>

--- a/demo/java/network-viewer-demo-data/README.md
+++ b/demo/java/network-viewer-demo-data/README.md
@@ -1,0 +1,49 @@
+# Synthetic NAD generator
+
+This module can generate a deterministic synthetic IIDM network and its SVG Network Area Diagram for performance
+testing.
+
+From this directory, generate a network with the given dimensions and a production-like stress profile with:
+
+```bash
+MAVEN_OPTS="-Xmx8g" mvn compile exec:java \
+  -Dexec.args="--voltage-levels 20000 --branches 40000 \
+  --profile stress \
+  --output ../../src/diagram-viewers/data/synthetic-grid-vl20k-b40k.svg"
+```
+
+`--branches` and `--average-degree` describe the same density through
+`average degree = 2 * branches / voltage levels`. At least one is required; when both are supplied, the generator
+checks that they are consistent. If only the average degree is supplied, the branch count is rounded to the nearest
+integer.
+
+Optional parameters:
+
+- `--profile`: `grid` by default, or `stress` for a production-like rendering workload.
+- `--seed`: topology seed, default `42`.
+- `--spacing`: base distance between nodes, default `220` for `grid` and `520` for `stress`.
+
+The `grid` profile is deliberately regular: one bus per voltage level, line branches only, a maximum degree close to
+the average degree, and short edges. It is useful as a stable baseline, but it is much easier for the SVG renderer
+than a real transmission network of the same size.
+
+The `stress` profile remains fully procedural and deterministic. It adds the structural characteristics that affect
+SVG interaction performance:
+
+- a heavy-tailed degree distribution with low-degree nodes and hubs;
+- a clustered layout and local branches with a broad length distribution;
+- multiple buses on some voltage levels and disconnected branch sides;
+- parallel circuits and loops, which produce bent polylines and curved SVG paths;
+- a production-like nominal-voltage distribution;
+- a mix of lines, two-winding transformers, phase-shifting transformers, and HVDC lines.
+
+It uses only aggregate ratios and the requested seed; it does not copy identifiers, coordinates, topology, or any
+other source-network data.
+
+The command writes both `synthetic-grid-vl20k-b40k.svg` and `synthetic-grid-vl20k-b40k_metadata.json`. Run the SVG performance
+benchmark from the repository root with:
+
+```bash
+NAD_SVG=demo/src/diagram-viewers/data/synthetic-grid-vl20k-b40k.svg \
+  npm run test:browser:performance -- --browser.headless=false
+```

--- a/demo/java/network-viewer-demo-data/pom.xml
+++ b/demo/java/network-viewer-demo-data/pom.xml
@@ -25,6 +25,7 @@
         <java.version>21</java.version>
         <core.version>7.3.0</core.version>
         <diagram.version>5.5.0</diagram.version>
+        <junit.version>5.12.2</junit.version>
         <olf.version>2.3.0</olf.version>
         <logback.version>1.5.26</logback.version>
     </properties>
@@ -101,6 +102,26 @@
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.3</version>
+                <configuration>
+                    <mainClass>com.powsybl.viewer.demo.SyntheticNadGenerator</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/demo/java/network-viewer-demo-data/src/main/java/com/powsybl/viewer/demo/SyntheticNadGenerator.java
+++ b/demo/java/network-viewer-demo-data/src/main/java/com/powsybl/viewer/demo/SyntheticNadGenerator.java
@@ -1,0 +1,998 @@
+/*
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.viewer.demo;
+
+import com.powsybl.iidm.network.Line;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.PhaseTapChanger;
+import com.powsybl.iidm.network.Substation;
+import com.powsybl.iidm.network.TopologyKind;
+import com.powsybl.iidm.network.TwoWindingsTransformer;
+import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.nad.NadParameters;
+import com.powsybl.nad.NetworkAreaDiagram;
+import com.powsybl.nad.build.iidm.VoltageLevelFilter;
+import com.powsybl.nad.layout.FixedLayoutFactory;
+import com.powsybl.nad.model.Point;
+import com.powsybl.nad.svg.EdgeInfoEnum;
+import com.powsybl.nad.svg.EdgeInfoParameters;
+import com.powsybl.nad.svg.LabelProviderParameters;
+import com.powsybl.nad.svg.SvgParameters;
+import com.powsybl.nad.svg.iidm.DefaultLabelProvider;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Random;
+import java.util.Set;
+import java.util.SplittableRandom;
+
+/**
+ * Generates a deterministic synthetic IIDM network and its SVG NAD for performance testing.
+ */
+public final class SyntheticNadGenerator {
+
+    private static final int DEFAULT_SEED = 42;
+    private static final double DEFAULT_GRID_SPACING = 220.0;
+    private static final double DEFAULT_STRESS_SPACING = 520.0;
+    private static final double AVERAGE_DEGREE_TOLERANCE = 0.01;
+    private static final double STRESS_TRANSFORMER_RATIO = 0.3167;
+    private static final double STRESS_PHASE_SHIFTER_RATIO = 0.0112;
+    private static final double STRESS_HVDC_RATIO = 0.0017;
+    private static final double STRESS_DISCONNECTED_SIDE_RATIO = 0.059;
+    private static final double STRESS_LOOP_RATIO = 369.0 / 29_938.0;
+    private static final int STRESS_REFERENCE_BRANCH_COUNT = 29_938;
+    private static final int[] STRESS_PARALLEL_MULTIPLICITIES = {2, 3, 4, 5, 6, 7, 9, 10};
+    private static final int[] STRESS_PARALLEL_GROUP_COUNTS = {3_428, 450, 196, 18, 40, 1, 1, 2};
+    private static final int STRESS_CLUSTER_SIDE = 10;
+
+    private SyntheticNadGenerator() {
+        // Utility class.
+    }
+
+    public static void main(String[] args) {
+        if (containsHelp(args)) {
+            printUsage();
+            return;
+        }
+
+        try {
+            GenerationOptions options = parseOptions(args);
+            generate(options);
+        } catch (IllegalArgumentException | IOException e) {
+            System.err.println("Error: " + e.getMessage());
+            System.err.println();
+            printUsage();
+            System.exit(2);
+        }
+    }
+
+    static void generate(GenerationOptions options) throws IOException {
+        Path output = options.output().toAbsolutePath().normalize();
+        if (output.getParent() != null) {
+            Files.createDirectories(output.getParent());
+        }
+
+        int columns = (int) Math.ceil(Math.sqrt(options.voltageLevelCount()));
+        Map<String, Point> positions = new HashMap<>(options.voltageLevelCount());
+
+        System.out.printf(Locale.ROOT,
+                "Generating synthetic IIDM network: %,d voltage levels, %,d branches, average degree %.4f%n",
+                options.voltageLevelCount(), options.branchCount(), options.averageDegree());
+        System.out.printf(Locale.ROOT, "Profile: %s | seed: %d | spacing: %.1f%n",
+                options.profile().cliName, options.seed(), options.spacing());
+
+        Instant networkStartedAt = Instant.now();
+        Network network = createNetwork(options, columns, positions);
+        Duration networkDuration = Duration.between(networkStartedAt, Instant.now());
+
+        Instant svgStartedAt = Instant.now();
+        NetworkAreaDiagram.draw(network, output, createNadParameters(positions), VoltageLevelFilter.NO_FILTER);
+        Duration svgDuration = Duration.between(svgStartedAt, Instant.now());
+
+        String svgFileName = output.getFileName().toString();
+        Path metadata = output.resolveSibling(svgFileName.substring(0, svgFileName.length() - 4) + "_metadata.json");
+        System.out.printf(Locale.ROOT, "%nSynthetic NAD generated successfully%n");
+        System.out.printf(Locale.ROOT, "SVG:      %s (%,d bytes)%n", output, Files.size(output));
+        System.out.printf(Locale.ROOT, "Metadata: %s (%,d bytes)%n", metadata, Files.size(metadata));
+        System.out.printf(Locale.ROOT, "Network construction: %.2f s%n", networkDuration.toMillis() / 1000.0);
+        System.out.printf(Locale.ROOT, "SVG generation:       %.2f s%n", svgDuration.toMillis() / 1000.0);
+    }
+
+    static Network createNetwork(GenerationOptions options, int columns, Map<String, Point> positions) {
+        Network network = Network.create("synthetic-nad", "synthetic");
+        Substation stressSubstation = options.profile() == GenerationProfile.STRESS
+                ? network.newSubstation().setId("SYNTHETIC_SUBSTATION").add()
+                : null;
+        List<String> voltageLevelIds = new ArrayList<>(options.voltageLevelCount());
+        List<List<String>> busIds = new ArrayList<>(options.voltageLevelCount());
+
+        for (int index = 0; index < options.voltageLevelCount(); index++) {
+            String voltageLevelId = "VL_" + index;
+            VoltageLevel voltageLevel = (stressSubstation == null
+                    ? network.newVoltageLevel()
+                    : stressSubstation.newVoltageLevel())
+                    .setId(voltageLevelId)
+                    .setName("VL " + index)
+                    .setNominalV(nominalVoltage(index, options.profile()))
+                    .setTopologyKind(TopologyKind.BUS_BREAKER)
+                    .add();
+            int busCount = options.profile() == GenerationProfile.STRESS
+                    ? stressBusCount(index, options.seed())
+                    : 1;
+            List<String> voltageLevelBusIds = new ArrayList<>(busCount);
+            for (int busIndex = 0; busIndex < busCount; busIndex++) {
+                String busId = "BUS_" + index + "_" + busIndex;
+                voltageLevel.getBusBreakerView().newBus()
+                        .setId(busId)
+                        .add();
+                if (options.profile() == GenerationProfile.STRESS) {
+                    var load = voltageLevel.newLoad()
+                            .setId("LOAD_" + index + "_" + busIndex)
+                            .setConnectableBus(busId)
+                            .setBus(busId)
+                            .setP0(10.0 + busIndex)
+                            .setQ0(3.0 + busIndex)
+                            .add();
+                    load.getTerminal().setP(10.0 + busIndex).setQ(3.0 + busIndex);
+                }
+                voltageLevelBusIds.add(busId);
+            }
+
+            voltageLevelIds.add(voltageLevelId);
+            busIds.add(voltageLevelBusIds);
+            positions.put(voltageLevelId, createPosition(index, columns, options));
+        }
+
+        List<Long> edges = options.profile() == GenerationProfile.STRESS
+                ? createStressBranches(options.voltageLevelCount(), options.branchCount(), columns, options.seed())
+                : new ArrayList<>(createEdges(
+                        options.voltageLevelCount(), options.branchCount(), columns, options.seed()));
+        List<BranchKind> branchKinds = createBranchKinds(options, edges);
+        int lineIndex = 0;
+        for (long encodedEdge : edges) {
+            int node1 = firstNode(encodedEdge);
+            int node2 = secondNode(encodedEdge);
+            String bus1 = selectBus(busIds.get(node1), lineIndex, 1, options.seed());
+            String bus2 = selectBus(busIds.get(node2), lineIndex, 2, options.seed());
+            if (node1 == node2 && bus1.equals(bus2) && busIds.get(node1).size() > 1) {
+                bus2 = busIds.get(node1).get((busIds.get(node1).indexOf(bus1) + 1) % busIds.get(node1).size());
+            }
+            boolean connected1 = isSideConnected(options, lineIndex, 1);
+            boolean connected2 = isSideConnected(options, lineIndex, 2);
+            createBranch(network, stressSubstation, branchKinds.get(lineIndex), lineIndex,
+                    voltageLevelIds.get(node1), bus1, connected1,
+                    voltageLevelIds.get(node2), bus2, connected2);
+            lineIndex++;
+        }
+        return network;
+    }
+
+    private static Point createPosition(int index, int columns, GenerationOptions options) {
+        double x = (index % columns) * options.spacing();
+        double y = (index / columns) * options.spacing();
+        if (options.profile() == GenerationProfile.STRESS) {
+            int column = index % columns;
+            int row = index / columns;
+            int clusterColumn = column / STRESS_CLUSTER_SIDE;
+            int clusterRow = row / STRESS_CLUSTER_SIDE;
+            int clusterIndex = clusterRow * ((columns + STRESS_CLUSTER_SIDE - 1) / STRESS_CLUSTER_SIDE)
+                    + clusterColumn;
+            double innerSpacing = options.spacing() * 0.67;
+            double clusterPitch = options.spacing() * 9.6;
+            double clusterJitter = options.spacing() * 1.5;
+            double nodeJitter = innerSpacing * 0.15;
+            x = clusterColumn * clusterPitch
+                    + (column % STRESS_CLUSTER_SIDE) * innerSpacing
+                    + signedUnitDouble(mix64(options.seed() + clusterIndex * 2L)) * clusterJitter
+                    + signedUnitDouble(mix64(options.seed() + index * 2L)) * nodeJitter;
+            y = clusterRow * clusterPitch
+                    + (row % STRESS_CLUSTER_SIDE) * innerSpacing
+                    + signedUnitDouble(mix64(options.seed() + clusterIndex * 2L + 1)) * clusterJitter
+                    + signedUnitDouble(mix64(options.seed() + index * 2L + 1)) * nodeJitter;
+        }
+        return new Point(x, y);
+    }
+
+    private static int stressBusCount(int nodeIndex, long seed) {
+        double value = unitDouble(mix64(seed ^ (0x632be59bd9b4e019L * (nodeIndex + 1L))));
+        if (value < 0.000055) {
+            return 8;
+        }
+        if (value < 0.00022) {
+            return 7;
+        }
+        if (value < 0.00088) {
+            return 6;
+        }
+        if (value < 0.00176) {
+            return 5;
+        }
+        if (value < 0.0049) {
+            return 4;
+        }
+        if (value < 0.0152) {
+            return 3;
+        }
+        if (value < 0.0906) {
+            return 2;
+        }
+        return 1;
+    }
+
+    private static String selectBus(List<String> busIds, int edgeIndex, int side, long seed) {
+        long hash = mix64(seed + 31L * edgeIndex + side * 0x9e3779b97f4a7c15L);
+        return busIds.get((int) Long.remainderUnsigned(hash, busIds.size()));
+    }
+
+    private static boolean isSideConnected(GenerationOptions options, int edgeIndex, int side) {
+        if (options.profile() != GenerationProfile.STRESS) {
+            return true;
+        }
+        long hash = mix64(options.seed() ^ (edgeIndex * 2L + side) * 0xd6e8feb86659fd93L);
+        return unitDouble(hash) >= STRESS_DISCONNECTED_SIDE_RATIO;
+    }
+
+    private static List<BranchKind> createBranchKinds(GenerationOptions options, List<Long> edges) {
+        List<BranchKind> branchKinds = new ArrayList<>(Collections.nCopies(options.branchCount(), BranchKind.LINE));
+        if (options.profile() != GenerationProfile.STRESS) {
+            return branchKinds;
+        }
+
+        int transformerCount = (int) Math.round(options.branchCount() * STRESS_TRANSFORMER_RATIO);
+        int phaseShifterCount = Math.min(transformerCount,
+                (int) Math.round(options.branchCount() * STRESS_PHASE_SHIFTER_RATIO));
+        int hvdcCount = Math.min(options.branchCount() - transformerCount,
+                (int) Math.round(options.branchCount() * STRESS_HVDC_RATIO));
+        for (int index = 0; index < transformerCount - phaseShifterCount; index++) {
+            branchKinds.set(index, BranchKind.TRANSFORMER);
+        }
+        for (int index = transformerCount - phaseShifterCount; index < transformerCount; index++) {
+            branchKinds.set(index, BranchKind.PHASE_SHIFTER);
+        }
+        for (int index = transformerCount; index < transformerCount + hvdcCount; index++) {
+            branchKinds.set(index, BranchKind.HVDC);
+        }
+        Collections.shuffle(branchKinds, new Random(options.seed() ^ 0x5deece66dL));
+        int nextLine = 0;
+        for (int index = 0; index < edges.size(); index++) {
+            if (firstNode(edges.get(index)) != secondNode(edges.get(index))
+                    || branchKinds.get(index) == BranchKind.LINE) {
+                continue;
+            }
+            while (nextLine < edges.size()
+                    && (branchKinds.get(nextLine) != BranchKind.LINE
+                    || firstNode(edges.get(nextLine)) == secondNode(edges.get(nextLine)))) {
+                nextLine++;
+            }
+            if (nextLine == edges.size()) {
+                throw new IllegalStateException("The stress profile requires more line branches for its loops");
+            }
+            BranchKind loopKind = branchKinds.get(index);
+            branchKinds.set(index, BranchKind.LINE);
+            branchKinds.set(nextLine, loopKind);
+            nextLine++;
+        }
+        return branchKinds;
+    }
+
+    private static void createBranch(Network network, Substation substation, BranchKind kind, int index,
+                                     String voltageLevel1, String bus1, boolean connected1,
+                                     String voltageLevel2, String bus2, boolean connected2) {
+        double activePower = 50.0 + index % 200;
+        double reactivePower = 10.0 + index % 50;
+        if (kind == BranchKind.LINE) {
+            var adder = network.newLine()
+                    .setId("LINE_" + index)
+                    .setName("L " + index)
+                    .setVoltageLevel1(voltageLevel1)
+                    .setConnectableBus1(bus1)
+                    .setVoltageLevel2(voltageLevel2)
+                    .setConnectableBus2(bus2)
+                    .setR(3.0)
+                    .setX(30.0)
+                    .setG1(0.0)
+                    .setB1(0.0)
+                    .setG2(0.0)
+                    .setB2(0.0);
+            if (connected1) {
+                adder.setBus1(bus1);
+            }
+            if (connected2) {
+                adder.setBus2(bus2);
+            }
+            Line line = adder.add();
+            line.getTerminal1().setP(activePower).setQ(reactivePower);
+            line.getTerminal2().setP(-activePower).setQ(-reactivePower);
+        } else if (kind == BranchKind.HVDC) {
+            createHvdcBranch(network, index, voltageLevel1, bus1, connected1,
+                    voltageLevel2, bus2, connected2, activePower, reactivePower);
+        } else {
+            var adder = substation.newTwoWindingsTransformer()
+                    .setId("TWT_" + index)
+                    .setName("T " + index)
+                    .setVoltageLevel1(voltageLevel1)
+                    .setConnectableBus1(bus1)
+                    .setVoltageLevel2(voltageLevel2)
+                    .setConnectableBus2(bus2)
+                    .setRatedU1(network.getVoltageLevel(voltageLevel1).getNominalV())
+                    .setRatedU2(network.getVoltageLevel(voltageLevel2).getNominalV())
+                    .setR(2.0)
+                    .setX(100.0)
+                    .setG(0.0)
+                    .setB(0.0);
+            if (connected1) {
+                adder.setBus1(bus1);
+            }
+            if (connected2) {
+                adder.setBus2(bus2);
+            }
+            TwoWindingsTransformer transformer = adder.add();
+            transformer.getTerminal1().setP(activePower).setQ(reactivePower);
+            transformer.getTerminal2().setP(-activePower).setQ(-reactivePower);
+            if (kind == BranchKind.PHASE_SHIFTER) {
+                addPhaseTapChanger(transformer);
+            }
+        }
+    }
+
+    private static void createHvdcBranch(Network network, int index,
+                                         String voltageLevel1, String bus1, boolean connected1,
+                                         String voltageLevel2, String bus2, boolean connected2,
+                                         double activePower, double reactivePower) {
+        String converter1Id = "VSC_" + index + "_1";
+        String converter2Id = "VSC_" + index + "_2";
+        var converter1Adder = network.getVoltageLevel(voltageLevel1).newVscConverterStation()
+                .setId(converter1Id)
+                .setConnectableBus(bus1)
+                .setLossFactor(1.0f)
+                .setVoltageSetpoint(network.getVoltageLevel(voltageLevel1).getNominalV())
+                .setVoltageRegulatorOn(true);
+        if (connected1) {
+            converter1Adder.setBus(bus1);
+        }
+        var converter1 = converter1Adder.add();
+        converter1.getTerminal().setP(activePower).setQ(reactivePower);
+
+        var converter2Adder = network.getVoltageLevel(voltageLevel2).newVscConverterStation()
+                .setId(converter2Id)
+                .setConnectableBus(bus2)
+                .setLossFactor(1.0f)
+                .setReactivePowerSetpoint(reactivePower)
+                .setVoltageRegulatorOn(false);
+        if (connected2) {
+            converter2Adder.setBus(bus2);
+        }
+        var converter2 = converter2Adder.add();
+        converter2.getTerminal().setP(-activePower).setQ(-reactivePower);
+
+        network.newHvdcLine()
+                .setId("HVDC_" + index)
+                .setName("H " + index)
+                .setConverterStationId1(converter1Id)
+                .setConverterStationId2(converter2Id)
+                .setR(1.0)
+                .setNominalV(400.0)
+                .setConvertersMode(com.powsybl.iidm.network.HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER)
+                .setMaxP(500.0)
+                .setActivePowerSetpoint(activePower)
+                .add();
+    }
+
+    private static void addPhaseTapChanger(TwoWindingsTransformer transformer) {
+        transformer.newPhaseTapChanger()
+                .setTapPosition(1)
+                .setRegulationTerminal(transformer.getTerminal2())
+                .setRegulationMode(PhaseTapChanger.RegulationMode.CURRENT_LIMITER)
+                .setRegulationValue(200.0)
+                .beginStep().setAlpha(-20.0).setRho(1.0).setR(0.0).setX(0.0).setG(0.0).setB(0.0).endStep()
+                .beginStep().setAlpha(0.0).setRho(1.0).setR(0.0).setX(0.0).setG(0.0).setB(0.0).endStep()
+                .beginStep().setAlpha(20.0).setRho(1.0).setR(0.0).setX(0.0).setG(0.0).setB(0.0).endStep()
+                .add();
+    }
+
+    static Set<Long> createEdges(int nodeCount, int edgeCount, int columns, long seed) {
+        Set<Long> edges = new LinkedHashSet<>(capacityFor(edgeCount));
+
+        // Connect every row from left to right.
+        for (int node = 1; node < nodeCount && edges.size() < edgeCount; node++) {
+            if (node % columns != 0) {
+                edges.add(encodeEdge(node - 1, node));
+            }
+        }
+        // Connect the rows together through their first node. With at least N-1
+        // branches, the generated graph is therefore connected.
+        int rowCount = (nodeCount + columns - 1) / columns;
+        for (int row = 1; row < rowCount && edges.size() < edgeCount; row++) {
+            edges.add(encodeEdge((row - 1) * columns, row * columns));
+        }
+
+        // Prefer short vertical branches before adding arbitrary chords.
+        List<Long> localCandidates = new ArrayList<>(Math.max(0, nodeCount - columns));
+        for (int node = 0; node + columns < nodeCount; node++) {
+            if (node % columns != 0) {
+                localCandidates.add(encodeEdge(node, node + columns));
+            }
+        }
+        Collections.shuffle(localCandidates, new Random(seed));
+        for (long candidate : localCandidates) {
+            if (edges.size() == edgeCount) {
+                break;
+            }
+            edges.add(candidate);
+        }
+
+        SplittableRandom random = new SplittableRandom(seed);
+        long rejectedCandidates = 0;
+        long rejectionLimit = Math.max(10_000L, nodeCount * 20L);
+        while (edges.size() < edgeCount && rejectedCandidates < rejectionLimit) {
+            int node1 = random.nextInt(nodeCount);
+            int node2 = random.nextInt(nodeCount - 1);
+            if (node2 >= node1) {
+                node2++;
+            }
+            if (edges.add(encodeEdge(node1, node2))) {
+                rejectedCandidates = 0;
+            } else {
+                rejectedCandidates++;
+            }
+        }
+
+        // Dense graphs cause many random collisions. Complete deterministically
+        // in that uncommon case so every valid requested branch count is supported.
+        for (int node1 = 0; edges.size() < edgeCount && node1 < nodeCount; node1++) {
+            for (int node2 = node1 + 1; edges.size() < edgeCount && node2 < nodeCount; node2++) {
+                edges.add(encodeEdge(node1, node2));
+            }
+        }
+        return edges;
+    }
+
+    static Set<Long> createStressEdges(int nodeCount, int edgeCount, int columns, long seed) {
+        return createStressEdges(nodeCount, edgeCount, columns, seed, 31);
+    }
+
+    private static Set<Long> createStressEdges(int nodeCount, int edgeCount, int columns, long seed,
+                                               int minimumMaximumDegree) {
+        if (edgeCount == 0) {
+            return Collections.emptySet();
+        }
+        for (int attempt = 0; attempt < 20; attempt++) {
+            SplittableRandom random = new SplittableRandom(seed + attempt * 0x9e3779b97f4a7c15L);
+            int[] degrees = createStressDegrees(nodeCount, edgeCount, minimumMaximumDegree, random);
+            Set<Long> edges = wireStressEdges(degrees, edgeCount, columns, random);
+            if (edges != null) {
+                return edges;
+            }
+        }
+        throw new IllegalStateException("Unable to create the requested stress topology");
+    }
+
+    static List<Long> createStressBranches(int nodeCount, int branchCount, int columns, long seed) {
+        if (branchCount == 0) {
+            return Collections.emptyList();
+        }
+
+        List<Integer> loopCandidates = new ArrayList<>();
+        for (int node = 0; node < nodeCount; node++) {
+            if (stressBusCount(node, seed) > 1) {
+                loopCandidates.add(node);
+            }
+        }
+        Collections.shuffle(loopCandidates, new Random(seed ^ 0x243f6a8885a308d3L));
+        int loopCount = Math.min(loopCandidates.size(), (int) Math.round(branchCount * STRESS_LOOP_RATIO));
+
+        int[] groupCounts = new int[STRESS_PARALLEL_GROUP_COUNTS.length];
+        int groupedBranchCount = 0;
+        int groupedPairCount = 0;
+        for (int index = 0; index < groupCounts.length; index++) {
+            groupCounts[index] = (int) Math.round((double) branchCount
+                    * STRESS_PARALLEL_GROUP_COUNTS[index] / STRESS_REFERENCE_BRANCH_COUNT);
+            groupedBranchCount += groupCounts[index] * STRESS_PARALLEL_MULTIPLICITIES[index];
+            groupedPairCount += groupCounts[index];
+        }
+        int singleBranchCount = branchCount - loopCount - groupedBranchCount;
+        if (singleBranchCount < 0) {
+            throw new IllegalArgumentException("The branch count is too small for the stress profile ratios");
+        }
+
+        int uniquePairCount = singleBranchCount + groupedPairCount;
+        List<Long> uniquePairs = new ArrayList<>(createStressEdges(
+                nodeCount, uniquePairCount, columns, seed, 20));
+        Collections.shuffle(uniquePairs, new Random(seed ^ 0x13198a2e03707344L));
+        List<Long> branches = new ArrayList<>(branchCount);
+        int pairIndex = 0;
+        for (; pairIndex < singleBranchCount; pairIndex++) {
+            branches.add(uniquePairs.get(pairIndex));
+        }
+        for (int groupIndex = 0; groupIndex < groupCounts.length; groupIndex++) {
+            int multiplicity = STRESS_PARALLEL_MULTIPLICITIES[groupIndex];
+            for (int group = 0; group < groupCounts[groupIndex]; group++) {
+                long pair = uniquePairs.get(pairIndex++);
+                for (int occurrence = 0; occurrence < multiplicity; occurrence++) {
+                    branches.add(pair);
+                }
+            }
+        }
+        for (int index = 0; index < loopCount; index++) {
+            int node = loopCandidates.get(index);
+            branches.add(encodeEdge(node, node));
+        }
+        Collections.shuffle(branches, new Random(seed ^ 0xa4093822299f31d0L));
+        return branches;
+    }
+
+    private static int[] createStressDegrees(int nodeCount, int edgeCount, int minimumMaximumDegree,
+                                             SplittableRandom random) {
+        int[] degrees = new int[nodeCount];
+        long requiredDegreeSum = edgeCount * 2L;
+        double averageDegree = (double) requiredDegreeSum / nodeCount;
+        int maximumDegree = Math.min(nodeCount - 1,
+                Math.max(minimumMaximumDegree, (int) Math.ceil(averageDegree * 4.0)));
+        double continuationProbability = averageDegree / (averageDegree + 1.0);
+        long degreeSum = 0;
+        for (int node = 0; node < nodeCount; node++) {
+            int degree = continuationProbability == 0
+                    ? 0
+                    : (int) Math.floor(Math.log1p(-random.nextDouble()) / Math.log(continuationProbability));
+            degrees[node] = Math.min(degree, maximumDegree);
+            degreeSum += degrees[node];
+        }
+
+        while (degreeSum < requiredDegreeSum) {
+            int node = random.nextInt(nodeCount);
+            if (degrees[node] < maximumDegree) {
+                degrees[node]++;
+                degreeSum++;
+            }
+        }
+        while (degreeSum > requiredDegreeSum) {
+            int node = random.nextInt(nodeCount);
+            if (degrees[node] > 0) {
+                degrees[node]--;
+                degreeSum--;
+            }
+        }
+        return degrees;
+    }
+
+    private static Set<Long> wireStressEdges(int[] degrees, int edgeCount, int columns,
+                                             SplittableRandom random) {
+        int[] remainingDegrees = degrees.clone();
+        PriorityQueue<DegreeEntry> queue = new PriorityQueue<>((left, right) -> {
+            int degreeComparison = Integer.compare(right.degree(), left.degree());
+            return degreeComparison != 0 ? degreeComparison : Integer.compare(left.node(), right.node());
+        });
+        for (int node = 0; node < remainingDegrees.length; node++) {
+            if (remainingDegrees[node] > 0) {
+                queue.add(new DegreeEntry(node, remainingDegrees[node]));
+            }
+        }
+
+        Set<Long> edges = new LinkedHashSet<>(capacityFor(edgeCount));
+        while (edges.size() < edgeCount) {
+            int node1 = pollNode(queue, remainingDegrees);
+            if (node1 < 0) {
+                return null;
+            }
+            int node2 = findStressNeighbour(node1, remainingDegrees, columns, edges, random);
+            if (node2 < 0) {
+                return null;
+            }
+
+            edges.add(encodeEdge(node1, node2));
+            remainingDegrees[node1]--;
+            remainingDegrees[node2]--;
+            if (remainingDegrees[node1] > 0) {
+                queue.add(new DegreeEntry(node1, remainingDegrees[node1]));
+            }
+            if (remainingDegrees[node2] > 0) {
+                queue.add(new DegreeEntry(node2, remainingDegrees[node2]));
+            }
+        }
+        return edges;
+    }
+
+    private static int findStressNeighbour(int node, int[] remainingDegrees, int columns, Set<Long> edges,
+                                           SplittableRandom random) {
+        int row = node / columns;
+        int column = node % columns;
+        int rowCount = (remainingDegrees.length + columns - 1) / columns;
+        for (int attempt = 0; attempt < 160; attempt++) {
+            int radius = Math.min(16,
+                    1 + (int) Math.floor(Math.log1p(-random.nextDouble()) / Math.log(0.25)));
+            double angle = random.nextDouble(2.0 * Math.PI);
+            int deltaColumn = (int) Math.round(radius * Math.cos(angle));
+            int deltaRow = (int) Math.round(radius * Math.sin(angle));
+            if (deltaColumn == 0 && deltaRow == 0) {
+                continue;
+            }
+            int candidateColumn = column + deltaColumn;
+            int candidateRow = row + deltaRow;
+            if (candidateColumn < 0 || candidateColumn >= columns || candidateRow < 0 || candidateRow >= rowCount) {
+                continue;
+            }
+            int candidate = candidateRow * columns + candidateColumn;
+            if (!sameStressCluster(node, candidate, columns) && random.nextDouble() >= 0.15) {
+                continue;
+            }
+            if (isAvailableNeighbour(node, candidate, remainingDegrees, edges)) {
+                return candidate;
+            }
+        }
+
+        int nearestCandidate = -1;
+        int nearestDistanceSquared = Integer.MAX_VALUE;
+        for (int candidate = 0; candidate < remainingDegrees.length; candidate++) {
+            if (!isAvailableNeighbour(node, candidate, remainingDegrees, edges)) {
+                continue;
+            }
+            int deltaColumn = stressLayoutCoordinate(candidate % columns) - stressLayoutCoordinate(column);
+            int deltaRow = stressLayoutCoordinate(candidate / columns) - stressLayoutCoordinate(row);
+            int distanceSquared = deltaColumn * deltaColumn + deltaRow * deltaRow;
+            if (distanceSquared < nearestDistanceSquared) {
+                nearestCandidate = candidate;
+                nearestDistanceSquared = distanceSquared;
+            }
+        }
+        return nearestCandidate;
+    }
+
+    private static boolean sameStressCluster(int node1, int node2, int columns) {
+        return node1 % columns / STRESS_CLUSTER_SIDE == node2 % columns / STRESS_CLUSTER_SIDE
+                && node1 / columns / STRESS_CLUSTER_SIDE == node2 / columns / STRESS_CLUSTER_SIDE;
+    }
+
+    private static int stressLayoutCoordinate(int coordinate) {
+        return coordinate / STRESS_CLUSTER_SIDE * 14 + coordinate % STRESS_CLUSTER_SIDE;
+    }
+
+    private static boolean isAvailableNeighbour(int node, int candidate, int[] remainingDegrees, Set<Long> edges) {
+        return candidate != node
+                && candidate >= 0
+                && candidate < remainingDegrees.length
+                && remainingDegrees[candidate] > 0
+                && !edges.contains(encodeEdge(node, candidate));
+    }
+
+    private static int pollNode(PriorityQueue<DegreeEntry> queue, int[] remainingDegrees) {
+        DegreeEntry entry = pollEntry(queue, remainingDegrees);
+        return entry == null ? -1 : entry.node();
+    }
+
+    private static DegreeEntry pollEntry(PriorityQueue<DegreeEntry> queue, int[] remainingDegrees) {
+        while (!queue.isEmpty()) {
+            DegreeEntry entry = queue.poll();
+            if (remainingDegrees[entry.node()] == entry.degree() && entry.degree() > 0) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    static GenerationOptions parseOptions(String[] args) {
+        Map<String, String> values = parseArguments(args);
+        int voltageLevelCount = parsePositiveInt(values, "--voltage-levels");
+        Integer requestedBranchCount = parseOptionalNonNegativeInt(values, "--branches");
+        Double requestedAverageDegree = parseOptionalNonNegativeDouble(values, "--average-degree");
+        if (requestedBranchCount == null && requestedAverageDegree == null) {
+            throw new IllegalArgumentException("Either --branches or --average-degree must be provided");
+        }
+
+        int branchCount = resolveBranchCount(voltageLevelCount, requestedBranchCount, requestedAverageDegree);
+        GenerationProfile profile = GenerationProfile.parse(values.getOrDefault("--profile", "grid"));
+        long seed = parseOptionalLong(values, "--seed", DEFAULT_SEED);
+        double defaultSpacing = profile == GenerationProfile.STRESS ? DEFAULT_STRESS_SPACING : DEFAULT_GRID_SPACING;
+        double spacing = parseOptionalPositiveDouble(values, "--spacing", defaultSpacing);
+        String outputValue = requiredValue(values, "--output");
+        Path output = Path.of(outputValue);
+        if (!output.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".svg")) {
+            throw new IllegalArgumentException("--output must reference an .svg file");
+        }
+        return new GenerationOptions(voltageLevelCount, branchCount, 2.0 * branchCount / voltageLevelCount,
+                profile, seed, spacing, output);
+    }
+
+    static int resolveBranchCount(int voltageLevelCount, Integer requestedBranchCount, Double requestedAverageDegree) {
+        long maximumBranchCount = (long) voltageLevelCount * (voltageLevelCount - 1) / 2;
+        long branchCount = requestedBranchCount != null
+                ? requestedBranchCount
+                : Math.round(requestedAverageDegree * voltageLevelCount / 2.0);
+        if (branchCount > maximumBranchCount) {
+            throw new IllegalArgumentException("The requested density requires " + branchCount
+                    + " branches, but a simple graph with " + voltageLevelCount
+                    + " voltage levels supports at most " + maximumBranchCount);
+        }
+        if (branchCount > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("The requested branch count exceeds the generator limit of "
+                    + Integer.MAX_VALUE);
+        }
+
+        double actualAverageDegree = 2.0 * branchCount / voltageLevelCount;
+        if (requestedBranchCount != null && requestedAverageDegree != null
+                && Math.abs(actualAverageDegree - requestedAverageDegree) > AVERAGE_DEGREE_TOLERANCE) {
+            throw new IllegalArgumentException(String.format(Locale.ROOT,
+                    "--branches %,d implies an average degree of %.4f, inconsistent with --average-degree %.4f",
+                    branchCount, actualAverageDegree, requestedAverageDegree));
+        }
+        return (int) branchCount;
+    }
+
+    private static NadParameters createNadParameters(Map<String, Point> positions) {
+        SvgParameters svgParameters = new SvgParameters()
+                .setCssLocation(SvgParameters.CssLocation.EXTERNAL_NO_IMPORT)
+                .setSvgWidthAndHeightAdded(true);
+        EdgeInfoParameters edgeInfoParameters = new EdgeInfoParameters(
+                EdgeInfoEnum.ACTIVE_POWER,
+                EdgeInfoEnum.NAME,
+                EdgeInfoEnum.REACTIVE_POWER,
+                EdgeInfoEnum.EMPTY);
+        LabelProviderParameters labelProviderParameters = new LabelProviderParameters();
+        labelProviderParameters.setEdgeInfoParameters(edgeInfoParameters);
+        return new NadParameters()
+                .setSvgParameters(svgParameters)
+                .setLayoutFactory(new FixedLayoutFactory(positions))
+                .setLabelProviderFactory((network, parameters) -> new DefaultLabelProvider(
+                        network, parameters.createValueFormatter(), labelProviderParameters));
+    }
+
+    private static Map<String, String> parseArguments(String[] args) {
+        Map<String, String> values = new HashMap<>();
+        Set<String> supportedOptions = Set.of(
+                "--voltage-levels", "--branches", "--average-degree", "--profile", "--output", "--seed",
+                "--spacing");
+        for (int index = 0; index < args.length; index += 2) {
+            String option = args[index];
+            if (!supportedOptions.contains(option)) {
+                throw new IllegalArgumentException("Unknown option: " + option);
+            }
+            if (index + 1 >= args.length) {
+                throw new IllegalArgumentException("Missing value for " + option);
+            }
+            if (values.put(option, args[index + 1]) != null) {
+                throw new IllegalArgumentException("Duplicate option: " + option);
+            }
+        }
+        return values;
+    }
+
+    private static int parsePositiveInt(Map<String, String> values, String option) {
+        int value = parseInt(requiredValue(values, option), option);
+        if (value <= 0) {
+            throw new IllegalArgumentException(option + " must be greater than zero");
+        }
+        return value;
+    }
+
+    private static Integer parseOptionalNonNegativeInt(Map<String, String> values, String option) {
+        String rawValue = values.get(option);
+        if (rawValue == null) {
+            return null;
+        }
+        int value = parseInt(rawValue, option);
+        if (value < 0) {
+            throw new IllegalArgumentException(option + " must be zero or greater");
+        }
+        return value;
+    }
+
+    private static Double parseOptionalNonNegativeDouble(Map<String, String> values, String option) {
+        String rawValue = values.get(option);
+        if (rawValue == null) {
+            return null;
+        }
+        double value = parseDouble(rawValue, option);
+        if (value < 0 || !Double.isFinite(value)) {
+            throw new IllegalArgumentException(option + " must be a finite number equal to or greater than zero");
+        }
+        return value;
+    }
+
+    private static double parseOptionalPositiveDouble(Map<String, String> values, String option, double defaultValue) {
+        String rawValue = values.get(option);
+        if (rawValue == null) {
+            return defaultValue;
+        }
+        double value = parseDouble(rawValue, option);
+        if (value <= 0 || !Double.isFinite(value)) {
+            throw new IllegalArgumentException(option + " must be a finite number greater than zero");
+        }
+        return value;
+    }
+
+    private static long parseOptionalLong(Map<String, String> values, String option, long defaultValue) {
+        String rawValue = values.get(option);
+        if (rawValue == null) {
+            return defaultValue;
+        }
+        try {
+            return Long.parseLong(rawValue);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(option + " must be an integer", e);
+        }
+    }
+
+    private static int parseInt(String rawValue, String option) {
+        try {
+            return Integer.parseInt(rawValue);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(option + " must be an integer", e);
+        }
+    }
+
+    private static double parseDouble(String rawValue, String option) {
+        try {
+            return Double.parseDouble(rawValue);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(option + " must be a number", e);
+        }
+    }
+
+    private static String requiredValue(Map<String, String> values, String option) {
+        String value = values.get(option);
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Missing required option " + option);
+        }
+        return value;
+    }
+
+    private static int capacityFor(int edgeCount) {
+        return edgeCount < 3 ? edgeCount + 1 : (int) Math.min(Integer.MAX_VALUE - 8L, edgeCount * 4L / 3L + 1L);
+    }
+
+    private static long encodeEdge(int node1, int node2) {
+        int first = Math.min(node1, node2);
+        int second = Math.max(node1, node2);
+        return ((long) first << 32) | (second & 0xffffffffL);
+    }
+
+    private static int firstNode(long edge) {
+        return (int) (edge >>> 32);
+    }
+
+    private static int secondNode(long edge) {
+        return (int) edge;
+    }
+
+    private static double nominalVoltage(int index, GenerationProfile profile) {
+        int bucket = Math.floorMod(index * 37, 10_000);
+        if (profile == GenerationProfile.STRESS) {
+            if (bucket < 1_117) {
+                return 20.0;
+            } else if (bucket < 1_580) {
+                return 45.0;
+            } else if (bucket < 3_453) {
+                return 63.0;
+            } else if (bucket < 5_261) {
+                return 90.0;
+            } else if (bucket < 6_082) {
+                return 150.0;
+            } else if (bucket < 8_063) {
+                return 225.0;
+            }
+            return 400.0;
+        }
+        bucket /= 10;
+        if (bucket < 546) {
+            return 63.0;
+        } else if (bucket < 739) {
+            return 90.0;
+        } else if (bucket < 914) {
+            return 225.0;
+        } else if (bucket < 958) {
+            return 400.0;
+        } else if (bucket < 977) {
+            return 20.0;
+        } else if (bucket < 989) {
+            return 45.0;
+        }
+        return 150.0;
+    }
+
+    private static long mix64(long value) {
+        long firstMix = (value ^ (value >>> 30)) * 0xbf58476d1ce4e5b9L;
+        long secondMix = (firstMix ^ (firstMix >>> 27)) * 0x94d049bb133111ebL;
+        return secondMix ^ (secondMix >>> 31);
+    }
+
+    private static double unitDouble(long value) {
+        return (value >>> 11) * 0x1.0p-53;
+    }
+
+    private static double signedUnitDouble(long value) {
+        return unitDouble(value) * 2.0 - 1.0;
+    }
+
+    private static boolean containsHelp(String[] args) {
+        for (String arg : args) {
+            if ("--help".equals(arg) || "-h".equals(arg)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void printUsage() {
+        System.out.println("""
+                Generate a deterministic synthetic IIDM network and its SVG NAD.
+
+                Usage:
+                  mvn compile exec:java -Dexec.args="\
+                    --voltage-levels <count> \
+                    [--branches <count>] \
+                    [--average-degree <degree>] \
+                    [--profile <grid|stress>] \
+                    --output <file.svg> \
+                    [--seed <integer>] \
+                    [--spacing <number>]"
+
+                Required:
+                  --voltage-levels   Number of voltage-level nodes to generate.
+                  --output           Destination SVG. The metadata JSON is written next to it.
+
+                Density:
+                  At least one of --branches or --average-degree is required.
+                  When both are provided they must satisfy average-degree = 2 * branches / voltage-levels.
+
+                Defaults:
+                  --profile          grid; use stress to reproduce production-like SVG complexity
+                  --seed             42
+                  --spacing          220 for grid, 520 for stress
+                """);
+    }
+
+    enum GenerationProfile {
+        GRID("grid"),
+        STRESS("stress");
+
+        private final String cliName;
+
+        GenerationProfile(String cliName) {
+            this.cliName = cliName;
+        }
+
+        private static GenerationProfile parse(String value) {
+            for (GenerationProfile profile : values()) {
+                if (profile.cliName.equalsIgnoreCase(value)) {
+                    return profile;
+                }
+            }
+            throw new IllegalArgumentException("--profile must be either grid or stress");
+        }
+    }
+
+    private enum BranchKind {
+        LINE,
+        TRANSFORMER,
+        PHASE_SHIFTER,
+        HVDC
+    }
+
+    private record DegreeEntry(int node, int degree) {
+    }
+
+    record GenerationOptions(
+            int voltageLevelCount,
+            int branchCount,
+            double averageDegree,
+            GenerationProfile profile,
+            long seed,
+            double spacing,
+            Path output) {
+    }
+}

--- a/demo/java/network-viewer-demo-data/src/test/java/com/powsybl/viewer/demo/SyntheticNadGeneratorTest.java
+++ b/demo/java/network-viewer-demo-data/src/test/java/com/powsybl/viewer/demo/SyntheticNadGeneratorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.viewer.demo;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.nad.model.Point;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SyntheticNadGeneratorTest {
+
+    @Test
+    void shouldParseConsistentDensityParameters() {
+        SyntheticNadGenerator.GenerationOptions options = SyntheticNadGenerator.parseOptions(new String[]{
+            "--voltage-levels", "100",
+            "--branches", "160",
+            "--average-degree", "3.2",
+            "--output", "synthetic.svg"
+        });
+
+        assertEquals(100, options.voltageLevelCount());
+        assertEquals(160, options.branchCount());
+        assertEquals(3.2, options.averageDegree());
+        assertEquals(SyntheticNadGenerator.GenerationProfile.GRID, options.profile());
+        assertEquals(220.0, options.spacing());
+        assertEquals(Path.of("synthetic.svg"), options.output());
+    }
+
+    @Test
+    void shouldDeriveBranchCountFromAverageDegree() {
+        SyntheticNadGenerator.GenerationOptions options = SyntheticNadGenerator.parseOptions(new String[]{
+            "--voltage-levels", "100",
+            "--average-degree", "3.2",
+            "--output", "synthetic.svg"
+        });
+
+        assertEquals(160, options.branchCount());
+    }
+
+    @Test
+    void shouldRejectInconsistentDensityParameters() {
+        String[] args = {
+            "--voltage-levels", "100",
+            "--branches", "160",
+            "--average-degree", "4.0",
+            "--output", "synthetic.svg"
+        };
+
+        assertThrows(IllegalArgumentException.class, () -> SyntheticNadGenerator.parseOptions(args));
+    }
+
+    @Test
+    void shouldParseStressProfileDefaults() {
+        SyntheticNadGenerator.GenerationOptions options = SyntheticNadGenerator.parseOptions(new String[]{
+            "--voltage-levels", "100",
+            "--branches", "160",
+            "--profile", "stress",
+            "--output", "synthetic.svg"
+        });
+
+        assertEquals(SyntheticNadGenerator.GenerationProfile.STRESS, options.profile());
+        assertEquals(520.0, options.spacing());
+    }
+
+    @Test
+    void shouldCreateTheExactRequestedTopology() {
+        Set<Long> firstRun = SyntheticNadGenerator.createEdges(100, 160, 10, 42);
+        Set<Long> secondRun = SyntheticNadGenerator.createEdges(100, 160, 10, 42);
+
+        assertEquals(160, firstRun.size());
+        assertEquals(firstRun, secondRun);
+
+        SyntheticNadGenerator.GenerationOptions options = new SyntheticNadGenerator.GenerationOptions(
+                100, 160, 3.2, SyntheticNadGenerator.GenerationProfile.GRID,
+                42, 220.0, Path.of("synthetic.svg"));
+        Map<String, Point> positions = new HashMap<>();
+        Network network = SyntheticNadGenerator.createNetwork(options, 10, positions);
+
+        assertEquals(100, network.getVoltageLevelStream().count());
+        assertEquals(160, network.getLineStream().count());
+        assertEquals(100, positions.size());
+    }
+
+    @Test
+    void shouldCreateDeterministicStressTopologyAndEquipmentMix() {
+        Set<Long> firstRun = SyntheticNadGenerator.createStressEdges(1_000, 1_635, 32, 42);
+        Set<Long> secondRun = SyntheticNadGenerator.createStressEdges(1_000, 1_635, 32, 42);
+
+        assertEquals(1_635, firstRun.size());
+        assertEquals(firstRun, secondRun);
+
+        List<Long> firstBranches = SyntheticNadGenerator.createStressBranches(1_000, 1_635, 32, 42);
+        List<Long> secondBranches = SyntheticNadGenerator.createStressBranches(1_000, 1_635, 32, 42);
+        assertEquals(1_635, firstBranches.size());
+        assertEquals(firstBranches, secondBranches);
+        assertEquals(20, firstBranches.stream()
+                .filter(edge -> (int) (edge >>> 32) == (int) (long) edge)
+                .count());
+        assertEquals(284, firstBranches.size() - Set.copyOf(firstBranches).size());
+
+        SyntheticNadGenerator.GenerationOptions options = new SyntheticNadGenerator.GenerationOptions(
+                1_000, 1_635, 3.27, SyntheticNadGenerator.GenerationProfile.STRESS,
+                42, 520.0, Path.of("synthetic-stress.svg"));
+        Map<String, Point> positions = new HashMap<>();
+        Network network = SyntheticNadGenerator.createNetwork(options, 32, positions);
+
+        assertEquals(1_000, network.getVoltageLevelStream().count());
+        assertEquals(1_114, network.getLineStream().count());
+        assertEquals(518, network.getTwoWindingsTransformerStream().count());
+        assertEquals(3, network.getHvdcLineStream().count());
+        assertEquals(18, network.getTwoWindingsTransformerStream()
+                .filter(transformer -> transformer.getPhaseTapChanger() != null)
+                .count());
+        assertEquals(1_000, positions.size());
+    }
+}

--- a/demo/map-viewer.html
+++ b/demo/map-viewer.html
@@ -23,6 +23,7 @@
             <h3>Contents</h3>
             <ul>
                 <li><a href="index.html">Network area diagram viewers</a></li>
+                <li><a href="nad-svg.html">SVG NAD browser</a></li>
                 <li><a href="map-viewer.html">Map viewers</a></li>
                 <li><a href="sld.html">Single-line diagram viewers</a></li>
                 <li><a href="synced-viewers.html">Synced viewers demo</a></li>

--- a/demo/nad-svg.html
+++ b/demo/nad-svg.html
@@ -1,0 +1,62 @@
+<!--
+  ~ Copyright (c) 2026, RTE (https://www.rte-france.com)
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  ~ SPDX-License-Identifier: MPL-2.0
+  -->
+
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#000000" />
+        <meta name="description" content="Interactive SVG NAD examples" />
+        <title>SVG NAD browser</title>
+        <link rel="stylesheet" href="src/style.css" />
+        <link rel="stylesheet" href="src/zoom.css" />
+        <link rel="stylesheet" href="src/demo.css" />
+    </head>
+    <body class="nad-svg-page">
+        <div class="floating-toc">
+            <h3>Contents</h3>
+            <ul>
+                <li><a href="index.html">SVG NAD gallery</a></li>
+                <li><a href="nad-svg.html" aria-current="page">SVG NAD browser</a></li>
+                <li><a href="map-viewer.html">Map viewers</a></li>
+                <li><a href="sld.html">Single-line diagram viewers</a></li>
+                <li><a href="synced-viewers.html">Synced viewers demo</a></li>
+            </ul>
+        </div>
+
+        <main class="nad-svg-page-content">
+            <header>
+                <h1>SVG NAD browser</h1>
+                <p>Load and interact with one network area diagram at a time.</p>
+            </header>
+
+            <section class="nad-svg-browser" aria-labelledby="nad-svg-title">
+                <div class="nad-svg-toolbar">
+                    <button id="nad-svg-previous" type="button" aria-label="Previous diagram">←</button>
+                    <label for="nad-svg-select">Diagram</label>
+                    <select id="nad-svg-select"></select>
+                    <button id="nad-svg-next" type="button" aria-label="Next diagram">→</button>
+                    <a id="nad-svg-link" target="_blank" rel="noreferrer">Open SVG</a>
+                    <a id="nad-svg-metadata-link" target="_blank" rel="noreferrer">Open metadata</a>
+                </div>
+
+                <div class="nad-svg-heading">
+                    <h2 id="nad-svg-title"></h2>
+                    <p id="nad-svg-description"></p>
+                    <p id="nad-svg-stats" class="nad-svg-stats" aria-live="polite"></p>
+                </div>
+
+                <div id="nad-svg-error" class="nad-svg-error" role="alert" hidden></div>
+                <div id="nad-svg-gallery-viewer" class="nad-svg-gallery-viewer"></div>
+            </section>
+        </main>
+
+        <script type="module" src="./src/nad-svg.ts"></script>
+    </body>
+</html>

--- a/demo/sld.html
+++ b/demo/sld.html
@@ -23,6 +23,7 @@
             <h3>Contents</h3>
             <ul>
                 <li><a href="index.html">Network area diagram viewers</a></li>
+                <li><a href="nad-svg.html">SVG NAD browser</a></li>
                 <li><a href="map-viewer.html">Map viewers</a></li>
                 <li><a href="sld.html">Single-line diagram viewers</a></li>
                 <li><a href="synced-viewers.html">Synced viewers demo</a></li>

--- a/demo/src/demo.css
+++ b/demo/src/demo.css
@@ -6,7 +6,7 @@
     padding: 15px;
     border: 1px solid #ccc;
     border-radius: 4px;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
     z-index: 1000;
     max-width: 200px;
 }
@@ -50,4 +50,118 @@
     border: 1px solid #ccc;
     border-bottom: none;
     border-radius: 4px 4px 0 0;
+}
+
+.nad-svg-page {
+    margin: 0;
+    color: #202124;
+    background: #f5f7fa;
+}
+
+.nad-svg-page-content {
+    box-sizing: border-box;
+    width: min(1600px, 100%);
+    margin: 0 auto;
+    padding: 24px;
+}
+
+.nad-svg-page-content > header {
+    padding-right: 220px;
+}
+
+.nad-svg-browser {
+    overflow: hidden;
+    background: white;
+    border: 1px solid #ccd2da;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(30, 45, 60, 0.1);
+}
+
+.nad-svg-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px;
+    background: #eef2f7;
+    border-bottom: 1px solid #ccd2da;
+}
+
+.nad-svg-toolbar select {
+    min-width: 280px;
+    max-width: 520px;
+    padding: 6px;
+}
+
+.nad-svg-toolbar button {
+    padding: 6px 10px;
+}
+
+.nad-svg-toolbar a {
+    color: #0066cc;
+}
+
+.nad-svg-heading {
+    padding: 12px 16px 4px;
+}
+
+.nad-svg-heading h2,
+.nad-svg-heading p {
+    margin: 0 0 8px;
+}
+
+.nad-svg-stats {
+    color: #56616f;
+    font-size: 0.9rem;
+}
+
+.nad-svg-error {
+    margin: 0 16px 12px;
+    padding: 10px;
+    color: #8a1c1c;
+    background: #fff0f0;
+    border: 1px solid #e1a0a0;
+    border-radius: 4px;
+}
+
+.nad-svg-gallery-viewer {
+    position: relative;
+    width: 100%;
+    height: max(600px, calc(100vh - 280px));
+    overflow: hidden;
+    background: white;
+    border-top: 1px solid #e0e3e7;
+}
+
+.nad-svg-gallery-viewer > #nad-viewer,
+.nad-svg-gallery-viewer #svg-container {
+    width: 100%;
+}
+
+.nad-svg-gallery-viewer[data-loading='true']::after {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    color: #56616f;
+    background: rgba(255, 255, 255, 0.85);
+    content: 'Loading…';
+}
+
+@media (max-width: 800px) {
+    .nad-svg-page-content {
+        padding: 8px;
+    }
+
+    .nad-svg-page-content > header {
+        padding-right: 0;
+    }
+
+    .nad-svg-toolbar {
+        flex-wrap: wrap;
+    }
+
+    .nad-svg-toolbar select {
+        min-width: 220px;
+        flex: 1;
+    }
 }

--- a/demo/src/nad-performance-fixture.d.ts
+++ b/demo/src/nad-performance-fixture.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+declare module 'virtual:nad-performance-fixture' {
+    export const benchmarkName: string;
+    export const svgUrl: string;
+    export const metadataUrl: string;
+}

--- a/demo/src/nad-svg-page.browser.test.ts
+++ b/demo/src/nad-svg-page.browser.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { afterEach, expect, test } from 'vitest';
+
+const waitForElement = async (selector: string): Promise<Element> => {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+        const element = document.querySelector(selector);
+        if (element) return element;
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(`Unable to find ${selector}`);
+};
+
+const waitForLoadedStats = async (): Promise<string> => {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+        const value = document.getElementById('nad-svg-stats')?.textContent ?? '';
+        if (value.includes('voltage levels')) return value;
+        await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error('The selected SVG NAD did not finish loading');
+};
+
+afterEach(() => {
+    window.dispatchEvent(new Event('beforeunload'));
+    document.body.replaceChildren();
+});
+
+test('loads and replaces one interactive SVG NAD at a time', async () => {
+    history.replaceState(null, '', `${window.location.pathname}?demo=nad-eurostag-tutorial-example1`);
+    document.body.innerHTML = `
+        <select id="nad-svg-select"></select>
+        <button id="nad-svg-previous"></button>
+        <button id="nad-svg-next"></button>
+        <a id="nad-svg-link"></a>
+        <a id="nad-svg-metadata-link"></a>
+        <h2 id="nad-svg-title"></h2>
+        <p id="nad-svg-description"></p>
+        <p id="nad-svg-stats"></p>
+        <div id="nad-svg-error" hidden></div>
+        <div id="nad-svg-gallery-viewer" style="width: 900px; height: 700px"></div>
+    `;
+
+    await import('./nad-svg');
+    const firstSvg = await waitForElement('#nad-svg-gallery-viewer svg');
+    const firstStats = await waitForLoadedStats();
+    expect(firstSvg.getAttribute('width')).toBe('900');
+    expect(firstStats).toContain('branches');
+    expect(document.querySelectorAll('#nad-svg-gallery-viewer > #nad-viewer')).toHaveLength(1);
+    expect(document.getElementById('nad-svg-link')?.getAttribute('href')).toBeTruthy();
+    expect(document.getElementById('nad-svg-metadata-link')?.getAttribute('href')).toBeTruthy();
+
+    const select = document.getElementById('nad-svg-select') as HTMLSelectElement;
+    expect(select.options.length).toBeGreaterThan(1);
+    select.value = '1';
+    select.dispatchEvent(new Event('change'));
+
+    const secondSvg = await waitForElement('#nad-svg-gallery-viewer svg');
+    await waitForLoadedStats();
+    expect(secondSvg).not.toBe(firstSvg);
+    expect(document.querySelectorAll('#nad-svg-gallery-viewer > #nad-viewer')).toHaveLength(1);
+    expect(document.getElementById('nad-svg-title')?.textContent).toBe('IEEE 9 — zero impedance and multiple buses');
+});

--- a/demo/src/nad-svg-performance.browser.test.ts
+++ b/demo/src/nad-svg-performance.browser.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { commands } from 'vitest/browser';
+import { afterAll, beforeAll, expect, test } from 'vitest';
+import type {
+    DiagramMetadata,
+    NodeMetadata,
+} from '../../packages/network-viewer-core/src/network-area-diagram-viewer/diagram-metadata';
+import { NetworkAreaDiagramViewer } from '../../packages/network-viewer-core/src/network-area-diagram-viewer/network-area-diagram-viewer';
+import { benchmarkName, metadataUrl, svgUrl } from 'virtual:nad-performance-fixture';
+import './style.css';
+import './zoom.css';
+
+declare module 'vitest/browser' {
+    interface BrowserCommands {
+        playwrightWheel(
+            selector: string,
+            relativeX: number,
+            relativeY: number,
+            deltaY: number,
+            steps: number,
+            stepDelayMs: number
+        ): Promise<void>;
+        playwrightDrag(
+            selector: string,
+            relativeStartX: number,
+            relativeStartY: number,
+            deltaX: number,
+            deltaY: number,
+            steps: number,
+            stepDelayMs: number
+        ): Promise<void>;
+        reportNadPerformance(
+            name: string,
+            devicePixelRatio: number,
+            initialLoadMs: number,
+            visibleLabelCount: number,
+            rows: Array<{ interaction: string } & FrameMetrics>
+        ): Promise<void>;
+    }
+}
+
+type FrameMetrics = {
+    durationMs: number;
+    frameCount: number;
+    averageFps: number;
+    p95FrameMs: number;
+    worstFrameMs: number;
+    stutterFrameCount: number;
+    longFrameCount: number;
+    stutterPercent: number;
+};
+
+type SvgMetrics = {
+    initialLoadMs: number;
+    zoom: FrameMetrics & { inputEventCount: number };
+    pan: FrameMetrics;
+    moveNode: FrameMetrics;
+    visibleLabelCount: number;
+};
+
+type DraggableNodeTarget = {
+    node: NodeMetadata;
+    relativePosition: [number, number];
+};
+
+const VIEWER_WIDTH = 900;
+const VIEWER_HEIGHT = 700;
+const LABEL_VIEW_WIDTH = 1000;
+const LABEL_VIEW_HEIGHT = 700;
+const WHEEL_DELTA_Y = -50;
+const ZOOM_EVENT_COUNT = 40;
+const INPUT_STEP_DELAY_MS = 16;
+const VIEWER_SETTLE_MS = 100;
+const MEASURED_SETTLE_FRAME_COUNT = 4;
+const PAN_STEPS = 30;
+const MOVE_STEPS = 30;
+const MINIMUM_FRAME_SAMPLE_COUNT = 20;
+const EXPECTED_FRAME_MS = 1000 / 60;
+const STUTTER_FRAME_MS = EXPECTED_FRAME_MS * 1.5;
+const LONG_FRAME_MS = 50;
+const INITIAL_LOAD_BUDGET_MS = 20_000;
+
+const SVG_CONTAINER_SELECTOR = '#nad-svg-benchmark';
+const SVG_INTERACTION_SELECTOR = `${SVG_CONTAINER_SELECTOR} > #nad-viewer > #svg-container > svg`;
+
+let metadata: DiagramMetadata;
+let svgContent: string;
+let container: HTMLDivElement | undefined;
+let svgViewer: NetworkAreaDiagramViewer | undefined;
+
+const createContainer = (): HTMLDivElement => {
+    const element = document.createElement('div');
+    element.id = SVG_CONTAINER_SELECTOR.slice(1);
+    element.style.width = `${VIEWER_WIDTH}px`;
+    element.style.height = `${VIEWER_HEIGHT}px`;
+    document.body.append(element);
+    return element;
+};
+
+const nextAnimationFrames = (count = 2): Promise<void> =>
+    new Promise((resolve) => {
+        const next = (remaining: number) => {
+            if (remaining === 0) resolve();
+            else requestAnimationFrame(() => next(remaining - 1));
+        };
+        next(count);
+    });
+
+const waitForViewerToSettle = async (): Promise<void> => {
+    await new Promise((resolve) => window.setTimeout(resolve, VIEWER_SETTLE_MS));
+    await nextAnimationFrames();
+};
+
+const percentile = (values: number[], ratio: number): number => {
+    if (values.length === 0) return 0;
+    const sorted = [...values].sort((left, right) => left - right);
+    return sorted[Math.min(Math.ceil(sorted.length * ratio) - 1, sorted.length - 1)];
+};
+
+const round = (value: number): number => Math.round(value * 10) / 10;
+
+const startFrameSampler = async (): Promise<() => FrameMetrics> => {
+    const intervals: number[] = [];
+    let previousTimestamp = await new Promise<number>((resolve) => requestAnimationFrame(resolve));
+    let animationFrame = 0;
+    const sample = (timestamp: number) => {
+        intervals.push(timestamp - previousTimestamp);
+        previousTimestamp = timestamp;
+        animationFrame = requestAnimationFrame(sample);
+    };
+    animationFrame = requestAnimationFrame(sample);
+
+    return () => {
+        cancelAnimationFrame(animationFrame);
+        const durationMs = intervals.reduce((sum, interval) => sum + interval, 0);
+        const stutterFrameCount = intervals.filter((interval) => interval > STUTTER_FRAME_MS).length;
+        return {
+            durationMs: round(durationMs),
+            frameCount: intervals.length,
+            averageFps: round((intervals.length * 1000) / Math.max(durationMs, 0.001)),
+            p95FrameMs: round(percentile(intervals, 0.95)),
+            worstFrameMs: round(Math.max(...intervals, 0)),
+            stutterFrameCount,
+            longFrameCount: intervals.filter((interval) => interval > LONG_FRAME_MS).length,
+            stutterPercent: round((stutterFrameCount * 100) / Math.max(intervals.length, 1)),
+        };
+    };
+};
+
+const measureInteraction = async (interaction: () => Promise<void>): Promise<FrameMetrics> => {
+    const stopFrameSampler = await startFrameSampler();
+    await interaction();
+    // Capture the debounced final rendering work without adding a fixed idle
+    // period that would dilute the interaction's frame-pacing metrics.
+    await nextAnimationFrames(MEASURED_SETTLE_FRAME_COUNT);
+    return stopFrameSampler();
+};
+
+const getBenchmarkNode = (viewer: NetworkAreaDiagramViewer): NodeMetadata => {
+    const incidentEdges = new Map<string, number>();
+    for (const edge of metadata.edges) {
+        incidentEdges.set(edge.node1, (incidentEdges.get(edge.node1) ?? 0) + 1);
+        incidentEdges.set(edge.node2, (incidentEdges.get(edge.node2) ?? 0) + 1);
+    }
+    const renderedNodes = metadata.nodes.filter((node) => {
+        if (node.invisible) return false;
+        const element = viewer.svgDiv.querySelector<SVGGraphicsElement>(`[id="${CSS.escape(node.svgId)}"]`);
+        const bounds = element?.getBoundingClientRect();
+        return bounds !== undefined && bounds.width > 0 && bounds.height > 0;
+    });
+    if (renderedNodes.length === 0) throw new Error('The NAD metadata contains no node rendered in the SVG');
+    return renderedNodes.reduce((mostConnected, node) =>
+        (incidentEdges.get(node.svgId) ?? 0) > (incidentEdges.get(mostConnected.svgId) ?? 0) ? node : mostConnected
+    );
+};
+
+const getRelativeNodePosition = (viewer: NetworkAreaDiagramViewer, node: NodeMetadata): [number, number] => {
+    const svg = container?.querySelector<SVGSVGElement>('svg');
+    const nodeElement = viewer.svgDiv.querySelector<SVGGraphicsElement>(`[id="${CSS.escape(node.svgId)}"]`);
+    if (!svg || !nodeElement) throw new Error(`Cannot locate SVG node "${node.equipmentId}"`);
+    const svgBounds = svg.getBoundingClientRect();
+    const nodeBounds = nodeElement.getBoundingClientRect();
+    return [
+        (nodeBounds.left + nodeBounds.width / 2 - svgBounds.left) / svgBounds.width,
+        (nodeBounds.top + nodeBounds.height / 2 - svgBounds.top) / svgBounds.height,
+    ];
+};
+
+const getDraggableNodeTarget = (viewer: NetworkAreaDiagramViewer, preferredNode: NodeMetadata): DraggableNodeTarget => {
+    const viewBox = viewer.getViewBox()!;
+    const visibleNodes = viewer.diagramMetadata!.nodes.filter(
+        ({ x, y, invisible }) =>
+            !invisible &&
+            x >= viewBox.x &&
+            x <= viewBox.x + viewBox.width &&
+            y >= viewBox.y &&
+            y <= viewBox.y + viewBox.height
+    );
+    const candidates = [preferredNode, ...visibleNodes.filter(({ svgId }) => svgId !== preferredNode.svgId)];
+    const relativePositions: Array<[number, number]> = [
+        [0.5, 0.5],
+        [0.3, 0.5],
+        [0.7, 0.5],
+        [0.5, 0.3],
+        [0.5, 0.7],
+    ];
+    for (const node of candidates) {
+        const element = viewer.svgDiv.querySelector<SVGGraphicsElement>(`[id="${CSS.escape(node.svgId)}"]`);
+        const bounds = element?.getBoundingClientRect();
+        if (!element || !bounds || bounds.width === 0 || bounds.height === 0) continue;
+        for (const relativePosition of relativePositions) {
+            const hitElement = document.elementFromPoint(
+                bounds.left + bounds.width * relativePosition[0],
+                bounds.top + bounds.height * relativePosition[1]
+            );
+            if (hitElement && element.contains(hitElement)) return { node, relativePosition };
+        }
+    }
+    throw new Error('Cannot find a visible SVG node that can receive a real pointer drag');
+};
+
+const zoomWithPlaywright = async (relativePosition: [number, number]): Promise<SvgMetrics['zoom']> => ({
+    ...(await measureInteraction(() =>
+        commands.playwrightWheel(
+            SVG_INTERACTION_SELECTOR,
+            relativePosition[0],
+            relativePosition[1],
+            WHEEL_DELTA_Y,
+            ZOOM_EVENT_COUNT,
+            INPUT_STEP_DELAY_MS
+        )
+    )),
+    inputEventCount: ZOOM_EVENT_COUNT,
+});
+
+const panWithPlaywright = (): Promise<FrameMetrics> =>
+    measureInteraction(() =>
+        commands.playwrightDrag(SVG_INTERACTION_SELECTOR, 0.15, 0.15, 300, 160, PAN_STEPS, INPUT_STEP_DELAY_MS)
+    );
+
+const moveNodeWithPlaywright = ({ node, relativePosition }: DraggableNodeTarget): Promise<FrameMetrics> =>
+    measureInteraction(() =>
+        commands.playwrightDrag(
+            `${SVG_CONTAINER_SELECTOR} [id="${CSS.escape(node.svgId)}"]`,
+            relativePosition[0],
+            relativePosition[1],
+            70,
+            35,
+            MOVE_STEPS,
+            INPUT_STEP_DELAY_MS
+        )
+    );
+
+const assertFrameMetrics = (metrics: FrameMetrics): void => {
+    expect(metrics.durationMs).toBeGreaterThan(0);
+    expect(metrics.frameCount).toBeGreaterThanOrEqual(MINIMUM_FRAME_SAMPLE_COUNT);
+    expect(metrics.averageFps).toBeGreaterThan(0);
+    expect(metrics.p95FrameMs).toBeGreaterThan(0);
+    expect(metrics.worstFrameMs).toBeGreaterThan(0);
+};
+
+beforeAll(async () => {
+    // Transfer and parse the potentially very large fixture before measuring
+    // viewer construction and its naturally scheduled initial frames.
+    const [svgResponse, metadataResponse] = await Promise.all([fetch(svgUrl), fetch(metadataUrl)]);
+    expect(svgResponse.ok).toBe(true);
+    expect(metadataResponse.ok).toBe(true);
+    const [loadedSvg, loadedMetadata] = await Promise.all([svgResponse.text(), metadataResponse.json()]);
+    svgContent = loadedSvg;
+    metadata = loadedMetadata as DiagramMetadata;
+}, 60_000);
+
+afterAll(() => {
+    svgViewer?.debounceToggleHoverCallback.cancel();
+    container?.remove();
+});
+
+test(`benchmarks ${benchmarkName} SVG frame pacing during real Playwright interactions`, async ({ annotate }) => {
+    expect(metadata.nodes.length).toBeGreaterThan(0);
+    container = createContainer();
+    await nextAnimationFrames();
+
+    const startedAt = performance.now();
+    svgViewer = new NetworkAreaDiagramViewer(container, svgContent, structuredClone(metadata), {
+        enableDragInteraction: true,
+        enableLevelOfDetail: true,
+        minWidth: VIEWER_WIDTH,
+        minHeight: VIEWER_HEIGHT,
+        maxWidth: VIEWER_WIDTH,
+        maxHeight: VIEWER_HEIGHT,
+        adaptiveTextZoom: { enabled: true, threshold: 3000 },
+    });
+    await nextAnimationFrames();
+    const initialLoadMs = performance.now() - startedAt;
+
+    const rootSvg = container.querySelector<SVGSVGElement>('svg');
+    expect(svgViewer.svgDraw?.node).toBe(rootSvg);
+    expect(svgViewer.innerSvg).toBeTruthy();
+    expect(typeof svgViewer.svgDraw?.panZoom).toBe('function');
+
+    const benchmarkNode = getBenchmarkNode(svgViewer);
+    const viewBoxBeforeZoom = svgViewer.getViewBox()!;
+    const zoom = await zoomWithPlaywright(getRelativeNodePosition(svgViewer, benchmarkNode));
+    expect(svgViewer.getViewBox()!.width).toBeLessThan(viewBoxBeforeZoom.width);
+
+    const viewBoxBeforePan = svgViewer.getViewBox()!;
+    const pan = await panWithPlaywright();
+    const viewBoxAfterPan = svgViewer.getViewBox()!;
+    expect(Math.hypot(viewBoxAfterPan.x - viewBoxBeforePan.x, viewBoxAfterPan.y - viewBoxBeforePan.y)).toBeGreaterThan(
+        0
+    );
+
+    svgViewer.setViewBox({
+        x: benchmarkNode.x - LABEL_VIEW_WIDTH / 2,
+        y: benchmarkNode.y - LABEL_VIEW_HEIGHT / 2,
+        width: LABEL_VIEW_WIDTH,
+        height: LABEL_VIEW_HEIGHT,
+    });
+    svgViewer.checkAndUpdateLevelOfDetail();
+    await waitForViewerToSettle();
+    const draggableNodeTarget = getDraggableNodeTarget(svgViewer, benchmarkNode);
+    const nodeBeforeMove = svgViewer.diagramMetadata!.nodes.find(
+        ({ svgId }) => svgId === draggableNodeTarget.node.svgId
+    )!;
+    const positionBeforeMove = { x: nodeBeforeMove.x, y: nodeBeforeMove.y };
+    const moveNode = await moveNodeWithPlaywright(draggableNodeTarget);
+    const nodeAfterMove = svgViewer.diagramMetadata!.nodes.find(
+        ({ svgId }) => svgId === draggableNodeTarget.node.svgId
+    )!;
+    expect(Math.hypot(nodeAfterMove.x - positionBeforeMove.x, nodeAfterMove.y - positionBeforeMove.y)).toBeGreaterThan(
+        0
+    );
+
+    const metrics: SvgMetrics = {
+        initialLoadMs: round(initialLoadMs),
+        zoom,
+        pan,
+        moveNode,
+        visibleLabelCount: container.querySelectorAll('g.nad-text-nodes > *, g.nad-edge-infos > *').length,
+    };
+    const benchmarkEnvironment = {
+        userAgent: navigator.userAgent,
+        devicePixelRatio: window.devicePixelRatio,
+    };
+    const benchmarkRows = (['zoom', 'pan', 'moveNode'] as const).map((interaction) => ({
+        renderer: 'SVG',
+        interaction,
+        ...metrics[interaction],
+    }));
+    await commands.reportNadPerformance(
+        benchmarkName,
+        benchmarkEnvironment.devicePixelRatio,
+        metrics.initialLoadMs,
+        metrics.visibleLabelCount,
+        benchmarkRows
+    );
+    await annotate(JSON.stringify({ benchmarkName, benchmarkEnvironment, metrics }, undefined, 2), 'benchmark');
+
+    expect(metrics.initialLoadMs).toBeLessThan(INITIAL_LOAD_BUDGET_MS);
+    expect(metrics.visibleLabelCount).toBeGreaterThan(0);
+    for (const row of benchmarkRows) assertFrameMetrics(row);
+}, 180_000);

--- a/demo/src/nad-svg.ts
+++ b/demo/src/nad-svg.ts
@@ -1,0 +1,271 @@
+/**
+ * Copyright (c) 2026, RTE (https://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { type DiagramMetadata, NetworkAreaDiagramViewer } from '../../packages/network-viewer-core/src';
+import {
+    handleLineBending,
+    handleNodeMove,
+    handleNodeSelect,
+    handleRightClick,
+    handleTextNodeMove,
+    handleToggleNadHover,
+} from './diagram-viewers/nad-callbacks';
+
+type ResourceLoader = () => Promise<string>;
+
+type NadSvgDemo = {
+    id: string;
+    title: string;
+    description: string;
+    order: number;
+    loadSvgUrl: ResourceLoader;
+    loadMetadataUrl: ResourceLoader;
+};
+
+const demoDetails: Record<string, { title: string; description: string; order: number }> = {
+    'nad-eurostag-tutorial-example1': {
+        title: 'Eurostag tutorial — basic',
+        description: 'Basic network with parallel and inverted branches.',
+        order: 10,
+    },
+    'nad-ieee9-zeroimpedance-cdf': {
+        title: 'IEEE 9 — zero impedance and multiple buses',
+        description: 'Partial network around VL3 with bus rings and zero-impedance branches.',
+        order: 20,
+    },
+    'nad-ieee9-zeroimpedance-cdf-middle-arrow': {
+        title: 'IEEE 9 — middle arrows',
+        description: 'Solved partial network with active power, current and middle branch information.',
+        order: 30,
+    },
+    'nad-ieee9-zeroimpedance-cdf-limit-percentage': {
+        title: 'IEEE 9 — permanent limit percentage',
+        description: 'Solved partial network with permanent and temporary current limits.',
+        order: 40,
+    },
+    'nad-ieee14cdf-solved': {
+        title: 'IEEE 14 — solved network',
+        description: 'Complete solved IEEE 14 network.',
+        order: 50,
+    },
+    'nad-ieee300cdf-VL9006': {
+        title: 'IEEE 300 — partial network with injections',
+        description: 'Depth-one view around VL9006, including injection symbols.',
+        order: 60,
+    },
+    'nad-four-substations': {
+        title: 'Four substations — PST and HVDC',
+        description: 'Phase-shifting transformer, three-winding transformer and HVDC links.',
+        order: 70,
+    },
+    'nad-four-substations-multiple-labels': {
+        title: 'Four substations — multiple labels',
+        description: 'Double arrows and multiple electrical values on each branch.',
+        order: 80,
+    },
+    'nad-four-substations_custom': {
+        title: 'Four substations — custom labels and styles',
+        description: 'Server-side style overrides and custom voltage-level legends.',
+        order: 90,
+    },
+    'nad-scada': {
+        title: 'SCADA — 3WT, boundary line and unknown bus',
+        description: 'Three-winding transformer, boundary equipment and an unknown-bus ring.',
+        order: 100,
+    },
+    'nad-double-arrows-with-middle-values': {
+        title: 'Components — double arrows and middle values',
+        description: 'SVC, VSC, shunt compensator and dangling-line network with double arrows.',
+        order: 110,
+    },
+    'nad-edge-info-components': {
+        title: 'Edge information components',
+        description: 'FLASH, LOCK and unknown component symbols in edge information labels.',
+        order: 120,
+    },
+    case1354pegase: {
+        title: 'PEGASE 1354 — large network',
+        description: 'Complete MATPOWER PEGASE case used to exercise SVG rendering and level of detail.',
+        order: 130,
+    },
+    bent_lines: {
+        title: 'Bent lines',
+        description: 'Network containing manually bent branch paths.',
+        order: 140,
+    },
+};
+
+const svgLoaders = import.meta.glob<string>('./diagram-viewers/data/*.svg', {
+    import: 'default',
+    query: '?url',
+});
+const metadataLoaders = import.meta.glob<string>('./diagram-viewers/data/*_metadata.json', {
+    import: 'default',
+    query: '?url',
+});
+
+const getId = (path: string): string => path.slice(path.lastIndexOf('/') + 1, -'.svg'.length);
+
+const getGeneratedTitle = (id: string): string =>
+    id
+        .replace(/^nad-/, '')
+        .replaceAll(/[-_]+/g, ' ')
+        .replaceAll(/\b(bp|cdf|hvdc|ieee|nad|pst|rte|scada|svg|vl)\b/gi, (value) => value.toUpperCase())
+        .replace(/^./, (value) => value.toUpperCase());
+
+const demos: NadSvgDemo[] = Object.entries(svgLoaders)
+    .flatMap(([svgPath, loadSvgUrl]) => {
+        const metadataPath = svgPath.replace(/\.svg$/, '_metadata.json');
+        const loadMetadataUrl = metadataLoaders[metadataPath];
+        if (!loadMetadataUrl) return [];
+        const id = getId(svgPath);
+        const details = demoDetails[id];
+        return [
+            {
+                id,
+                title: details?.title ?? getGeneratedTitle(id),
+                description: details?.description ?? 'Procedurally generated or locally supplied SVG NAD.',
+                order: details?.order ?? 1_000,
+                loadSvgUrl,
+                loadMetadataUrl,
+            },
+        ];
+    })
+    .sort((left, right) => left.order - right.order || left.title.localeCompare(right.title));
+
+const select = document.getElementById('nad-svg-select') as HTMLSelectElement;
+const previousButton = document.getElementById('nad-svg-previous') as HTMLButtonElement;
+const nextButton = document.getElementById('nad-svg-next') as HTMLButtonElement;
+const svgLink = document.getElementById('nad-svg-link') as HTMLAnchorElement;
+const metadataLink = document.getElementById('nad-svg-metadata-link') as HTMLAnchorElement;
+const title = document.getElementById('nad-svg-title') as HTMLHeadingElement;
+const description = document.getElementById('nad-svg-description') as HTMLParagraphElement;
+const stats = document.getElementById('nad-svg-stats') as HTMLParagraphElement;
+const errorBox = document.getElementById('nad-svg-error') as HTMLDivElement;
+const container = document.getElementById('nad-svg-gallery-viewer') as HTMLDivElement;
+
+let viewer: NetworkAreaDiagramViewer | undefined;
+let selectedIndex = 0;
+let loadRevision = 0;
+let loadAbortController: AbortController | undefined;
+
+for (const [index, demo] of demos.entries()) {
+    const option = document.createElement('option');
+    option.value = String(index);
+    option.textContent = demo.title;
+    select.append(option);
+}
+
+const showError = (error: unknown) => {
+    errorBox.textContent = error instanceof Error ? error.message : String(error);
+    errorBox.hidden = false;
+};
+
+const updateNavigation = () => {
+    select.value = String(selectedIndex);
+    previousButton.disabled = selectedIndex === 0;
+    nextButton.disabled = selectedIndex === demos.length - 1;
+};
+
+const updateUrl = (demo: NadSvgDemo) => {
+    const url = new URL(window.location.href);
+    url.searchParams.set('demo', demo.id);
+    history.replaceState(null, '', url);
+};
+
+const fetchResource = async (url: string, resourceName: string, signal: AbortSignal): Promise<Response> => {
+    const response = await fetch(url, { signal });
+    if (!response.ok) throw new Error(`Unable to load ${resourceName}: HTTP ${response.status}`);
+    return response;
+};
+
+const formatStats = (metadata: DiagramMetadata): string =>
+    `${metadata.nodes.length.toLocaleString()} voltage levels · ` +
+    `${metadata.busNodes.length.toLocaleString()} buses · ` +
+    `${metadata.edges.length.toLocaleString()} branches · ` +
+    `${metadata.textNodes.length.toLocaleString()} labels`;
+
+const loadDemo = async (index: number) => {
+    if (demos.length === 0) {
+        showError('No SVG and metadata pair was found in the NAD data directory.');
+        return;
+    }
+
+    selectedIndex = Math.max(0, Math.min(demos.length - 1, index));
+    const revision = ++loadRevision;
+    loadAbortController?.abort();
+    loadAbortController = new AbortController();
+    const { signal } = loadAbortController;
+    const demo = demos[selectedIndex];
+
+    updateNavigation();
+    updateUrl(demo);
+    viewer?.debounceToggleHoverCallback.cancel();
+    viewer = undefined;
+    container.replaceChildren();
+    container.dataset.loading = 'true';
+    errorBox.hidden = true;
+    title.textContent = demo.title;
+    description.textContent = demo.description;
+    stats.textContent = 'Loading SVG and metadata…';
+    svgLink.removeAttribute('href');
+    metadataLink.removeAttribute('href');
+
+    try {
+        const [svgUrl, metadataUrl] = await Promise.all([demo.loadSvgUrl(), demo.loadMetadataUrl()]);
+        const [svgContent, metadata] = await Promise.all([
+            fetchResource(svgUrl, 'SVG', signal).then((response) => response.text()),
+            fetchResource(metadataUrl, 'SVG metadata', signal).then((response) => response.json()),
+        ]);
+        if (revision !== loadRevision) return;
+
+        svgLink.href = svgUrl;
+        metadataLink.href = metadataUrl;
+        const viewerWidth = Math.max(320, container.clientWidth);
+        const viewerHeight = Math.max(500, container.clientHeight);
+        viewer = new NetworkAreaDiagramViewer(container, svgContent, metadata as DiagramMetadata, {
+            enableDragInteraction: true,
+            enableLevelOfDetail: true,
+            addButtons: true,
+            minWidth: viewerWidth,
+            minHeight: viewerHeight,
+            maxWidth: viewerWidth,
+            maxHeight: viewerHeight,
+            onMoveNodeCallback: handleNodeMove,
+            onMoveTextNodeCallback: handleTextNodeMove,
+            onSelectNodeCallback: handleNodeSelect,
+            onToggleHoverCallback: handleToggleNadHover,
+            onRightClickCallback: handleRightClick,
+            onBendLineCallback: handleLineBending,
+            adaptiveTextZoom: { enabled: true, threshold: 3000 },
+        });
+        stats.textContent = formatStats(metadata as DiagramMetadata);
+    } catch (error) {
+        if (revision !== loadRevision || signal.aborted) return;
+        stats.textContent = 'SVG viewer unavailable';
+        showError(error);
+    } finally {
+        if (revision === loadRevision) delete container.dataset.loading;
+    }
+};
+
+select.addEventListener('change', () => void loadDemo(Number(select.value)));
+previousButton.addEventListener('click', () => void loadDemo(selectedIndex - 1));
+nextButton.addEventListener('click', () => void loadDemo(selectedIndex + 1));
+window.addEventListener(
+    'beforeunload',
+    () => {
+        viewer?.debounceToggleHoverCallback.cancel();
+        loadAbortController?.abort();
+    },
+    { once: true }
+);
+
+const requestedDemo = new URLSearchParams(window.location.search).get('demo');
+const requestedIndex = requestedDemo ? demos.findIndex((demo) => demo.id === requestedDemo) : 0;
+void loadDemo(Math.max(0, requestedIndex));

--- a/demo/synced-viewers.html
+++ b/demo/synced-viewers.html
@@ -47,6 +47,7 @@
             <h3>Contents</h3>
             <ul>
                 <li><a href="index.html">Network area diagram viewers</a></li>
+                <li><a href="nad-svg.html">SVG NAD browser</a></li>
                 <li><a href="map-viewer.html">Map viewers</a></li>
                 <li><a href="sld.html">Single-line diagram viewers</a></li>
                 <li><a href="synced-viewers.html">Synced viewers demo</a></li>

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig((config) => ({
         rolldownOptions: {
             input: {
                 main: path.resolve(import.meta.dirname, 'index.html'),
+                nadSvg: path.resolve(import.meta.dirname, 'nad-svg.html'),
                 sld: path.resolve(import.meta.dirname, 'sld.html'),
                 maps: path.resolve(import.meta.dirname, 'map-viewer.html'),
                 syncedViewers: path.resolve(import.meta.dirname, 'synced-viewers.html'),

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "test": "vitest run",
         "test:unit": "vitest run --project unit-tests",
         "test:browser": "vitest run --project browser-tests",
+        "test:browser:performance": "vitest run --config vitest.performance.config.ts",
         "test:coverage": "vitest run --coverage",
         "start": "vite demo/ --config demo/vite.config.ts",
         "start:open": "vite demo/ --config demo/vite.config.ts --open",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
         "eslint.config.js",
         "prettier.config.js",
         "vitest.config.ts",
+        "vitest.performance.config.ts",
         "vite.config.ts"
     ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
                 test: {
                     name: 'browser-tests',
                     include: ['**/*.browser.test.{ts,tsx}'],
+                    exclude: [...configDefaults.exclude, '**/*performance.browser.test.{ts,tsx}'],
                     globals: true,
                     testTimeout: 30000,
                     browser: {

--- a/vitest.performance.config.ts
+++ b/vitest.performance.config.ts
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { createReadStream, existsSync } from 'node:fs';
+import { basename, extname, resolve } from 'node:path';
+import react from '@vitejs/plugin-react';
+import { playwright } from '@vitest/browser-playwright';
+import type { Plugin } from 'vite';
+import type { BrowserCommandContext } from 'vitest/node';
+import { defineConfig } from 'vitest/config';
+
+const FIXTURE_MODULE_ID = 'virtual:nad-performance-fixture';
+const RESOLVED_FIXTURE_MODULE_ID = `\0${FIXTURE_MODULE_ID}`;
+const SVG_FIXTURE_URL = '/__nad-performance-fixture/diagram.svg';
+const METADATA_FIXTURE_URL = '/__nad-performance-fixture/metadata.json';
+
+type BenchmarkRow = {
+    interaction: string;
+    durationMs: number;
+    frameCount: number;
+    averageFps: number;
+    p95FrameMs: number;
+    worstFrameMs: number;
+    stutterFrameCount: number;
+    longFrameCount: number;
+    stutterPercent: number;
+};
+
+const svgPathArgument = process.env.NAD_SVG;
+if (!svgPathArgument) {
+    throw new Error(
+        'Missing NAD_SVG. Usage: NAD_SVG=demo/src/diagram-viewers/data/case1354pegase.svg npm run test:browser:performance'
+    );
+}
+
+const svgPath = resolve(svgPathArgument);
+const metadataPath = resolve(
+    process.env.NAD_METADATA ?? `${svgPath.slice(0, svgPath.length - extname(svgPath).length)}_metadata.json`
+);
+
+for (const [kind, filePath] of [
+    ['SVG', svgPath],
+    ['metadata', metadataPath],
+] as const) {
+    if (!existsSync(filePath)) throw new Error(`Cannot find the NAD ${kind} file: ${filePath}`);
+}
+if (extname(svgPath).toLowerCase() !== '.svg') throw new Error(`NAD_SVG must reference an .svg file: ${svgPath}`);
+
+const nadPerformanceFixture = (): Plugin => ({
+    name: 'nad-performance-fixture',
+    configureServer(server) {
+        server.middlewares.use(SVG_FIXTURE_URL, (_request, response) => {
+            response.statusCode = 200;
+            response.setHeader('Content-Type', 'image/svg+xml; charset=utf-8');
+            createReadStream(svgPath).pipe(response);
+        });
+        server.middlewares.use(METADATA_FIXTURE_URL, (_request, response) => {
+            response.statusCode = 200;
+            response.setHeader('Content-Type', 'application/json; charset=utf-8');
+            createReadStream(metadataPath).pipe(response);
+        });
+    },
+    resolveId(id) {
+        return id === FIXTURE_MODULE_ID ? RESOLVED_FIXTURE_MODULE_ID : undefined;
+    },
+    load(id) {
+        if (id !== RESOLVED_FIXTURE_MODULE_ID) return undefined;
+        return [
+            `export const benchmarkName = ${JSON.stringify(basename(svgPath))};`,
+            `export const svgUrl = ${JSON.stringify(SVG_FIXTURE_URL)};`,
+            `export const metadataUrl = ${JSON.stringify(METADATA_FIXTURE_URL)};`,
+        ].join('\n');
+    },
+});
+
+export default defineConfig({
+    plugins: [nadPerformanceFixture(), react()],
+    test: {
+        include: ['demo/src/nad-svg-performance.browser.test.ts'],
+        globals: true,
+        testTimeout: 180_000,
+        browser: {
+            enabled: true,
+            provider: playwright(),
+            headless: true,
+            commands: {
+                async playwrightWheel(
+                    { page, iframe }: BrowserCommandContext,
+                    selector: string,
+                    relativeX: number,
+                    relativeY: number,
+                    deltaY: number,
+                    steps: number,
+                    stepDelayMs: number
+                ) {
+                    const box = await iframe.locator(selector).boundingBox();
+                    if (!box) throw new Error(`Cannot find the interaction target "${selector}"`);
+                    await page.mouse.move(box.x + box.width * relativeX, box.y + box.height * relativeY);
+                    for (let step = 0; step < steps; step += 1) {
+                        await page.mouse.wheel(0, deltaY);
+                        await page.waitForTimeout(stepDelayMs);
+                    }
+                },
+                async playwrightDrag(
+                    { page, iframe }: BrowserCommandContext,
+                    selector: string,
+                    relativeStartX: number,
+                    relativeStartY: number,
+                    deltaX: number,
+                    deltaY: number,
+                    steps: number,
+                    stepDelayMs: number
+                ) {
+                    const box = await iframe.locator(selector).boundingBox();
+                    if (!box) throw new Error(`Cannot find the interaction target "${selector}"`);
+                    const startX = box.x + box.width * relativeStartX;
+                    const startY = box.y + box.height * relativeStartY;
+                    await page.mouse.move(startX, startY);
+                    await page.waitForTimeout(stepDelayMs);
+                    await page.mouse.down();
+                    for (let step = 1; step <= steps; step += 1) {
+                        await page.mouse.move(startX + (deltaX * step) / steps, startY + (deltaY * step) / steps);
+                        await page.waitForTimeout(stepDelayMs);
+                    }
+                    await page.mouse.up();
+                },
+                reportNadPerformance(
+                    _context: BrowserCommandContext,
+                    name: string,
+                    devicePixelRatio: number,
+                    initialLoadMs: number,
+                    visibleLabelCount: number,
+                    rows: BenchmarkRow[]
+                ) {
+                    const tableRows = rows.map((row) => [
+                        row.interaction,
+                        `${row.durationMs.toFixed(1)} ms`,
+                        String(row.frameCount),
+                        row.averageFps.toFixed(1),
+                        `${row.p95FrameMs.toFixed(1)} ms`,
+                        `${row.worstFrameMs.toFixed(1)} ms`,
+                        `${row.stutterFrameCount} (${row.stutterPercent.toFixed(1)}%)`,
+                        String(row.longFrameCount),
+                    ]);
+                    const headers = [
+                        'Interaction',
+                        'Duration',
+                        'Frames',
+                        'Avg FPS',
+                        'p95 frame',
+                        'Worst frame',
+                        'Stutters',
+                        'Long frames',
+                    ];
+                    const widths = headers.map((header, index) =>
+                        Math.max(header.length, ...tableRows.map((row) => row[index].length))
+                    );
+                    const formatRow = (row: string[]): string =>
+                        row.map((cell, index) => cell.padEnd(widths[index])).join('  ');
+                    const separator = widths.map((width) => '-'.repeat(width)).join('  ');
+
+                    console.info(
+                        [
+                            '',
+                            `NAD SVG performance benchmark: ${name}`,
+                            `Browser: Chromium | Device pixel ratio: ${devicePixelRatio}`,
+                            `Initial load: ${initialLoadMs.toFixed(1)} ms | Visible labels: ${visibleLabelCount}`,
+                            '',
+                            formatRow(headers),
+                            separator,
+                            ...tableRows.map(formatRow),
+                            '',
+                        ].join('\n')
+                    );
+                },
+            },
+            instances: [{ browser: 'chromium', viewport: { width: 1000, height: 1000 } }],
+        },
+    },
+});


### PR DESCRIPTION
- Added an SVG-only NAD performance benchmark using Vitest Browser Mode and Playwright.
  - No deck.gl or canvas dependency.
  - Accepts any SVG through `NAD_SVG`.
  - Automatically infers the adjacent `_metadata.json` file.
  - Supports an explicit metadata file through `NAD_METADATA`.
  - Streams large fixtures through Vite middleware to avoid Node.js memory issues.
  - Measures initial loading, zooming, panning, and node movement.
  - Prints a readable textual report with FPS, p95 frame time, worst frame, stutters, and long frames.

- Added a procedural IIDM/NAD generator:
  - Configurable voltage-level count, branch count, and average degree.
  - Deterministic output through a configurable random seed.
  - Generates both the NAD SVG and its metadata JSON.
  - Provides two profiles:
    - `grid`: regular, relatively lightweight topology.
    - `stress`: hubs, clustered placement, parallel circuits, loops, transformers, phase shifters, HVDC links, disconnected bus sides, and heterogeneous voltage levels.
  - Includes Maven CLI integration, documentation, and six unit tests.

- Added an SVG-only NAD demo viewer:
  - Displays one NAD at a time.
  - Automatically discovers SVG/metadata pairs.
  - Lazily loads only the selected network.
  - Provides previous/next navigation and network selection.
  - Supports zooming, panning, node dragging, tooltips, context menus, edge bending, LOD, and adaptive label visibility.
  - Preserves the selected network in `?demo=<id>`.
  - Added navigation links from the existing demo pages.
  - Added a Vitest browser test for viewer selection and replacement.

- Updated TypeScript declarations, Vite inputs, demo styling, Maven configuration, and performance-test configuration.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**What kind of change does this PR introduce?**
NAD performance benchmark



**What is the current behavior?**
no objective benchmark



**What is the new behavior (if this is a feature change)?**
NAD performance benchmark


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No